### PR TITLE
Quick Editor: Encode URL parameters

### DIFF
--- a/web/packages/quick-editor/playground/index.ts
+++ b/web/packages/quick-editor/playground/index.ts
@@ -7,7 +7,7 @@ import type { ProfileUpdatedType } from '../dist';
 document.addEventListener( 'DOMContentLoaded', () => {
 	new GravatarQuickEditor( {
 		email: 'joao.heringer@automattic.com',
-		scope: [ 'avatars', 'about' ],
+		scope: [ 'avatars' ],
 		editorTriggerSelector: '#edit-avatar',
 		avatarSelector: '.avatar',
 	} );

--- a/web/packages/quick-editor/src/quick-editor-core.ts
+++ b/web/packages/quick-editor/src/quick-editor-core.ts
@@ -65,13 +65,16 @@ export class GravatarQuickEditorCore {
 			return;
 		}
 
+		email = encodeURIComponent( email );
+		const scope = encodeURIComponent( this._scope.join( ',' ) );
+
 		const width = 400;
 		const height = 720;
 		const left = window.screenLeft + ( window.outerWidth - width ) / 2;
 		const top = window.screenTop + ( window.outerHeight - height ) / 2;
 		const options = `popup,width=${ width },height=${ height },top=${ top },left=${ left }`;
 		const host = this._local ? `https://${ this._local }.gravatar.com` : 'https://gravatar.com';
-		const url = `${ host }/profile?email=${ email }&scope=${ this._scope.join( ',' ) }&is_quick_editor=true`;
+		const url = `${ host }/profile?email=${ email }&scope=${ scope }&is_quick_editor=true`;
 
 		window.open( url, this._name, options );
 


### PR DESCRIPTION
## Proposed Changes

For the login flow to work properly, especially while handling `email+123@provider.com` cases, we need to encode the URL parameters.

## Testing Instructions

* The easiest way to test it is to throw a `console.log(url)` [here](https://github.com/Automattic/gravatar/pull/28/files#diff-33471df6c68e702f88ed75df6024470aef629542105f2314645837be7e1721e8R78)
* Run `npm run start`
* Click the "Edit Profile" button and check if the URL parameters are encoded in the browser console.log
