### PR TITLE
Hovercards: Format files

### DIFF
--- a/web/packages/hovercards/.eslintrc.js
+++ b/web/packages/hovercards/.eslintrc.js
@@ -3,8 +3,10 @@ module.exports = {
 		ecmaVersion: 'latest',
 		sourceType: 'module',
 	},
-	extends: ['plugin:@wordpress/eslint-plugin/recommended'],
+	extends: [ 'plugin:@wordpress/eslint-plugin/recommended' ],
+	plugins: [ 'prettier' ],
 	rules: {
+		'prettier/prettier': [ 'error', require( './.prettierrc.js' ) ], // Uses our .prettierrc.js config
 		'@wordpress/i18n-no-variables': 'off',
 	},
 };

--- a/web/packages/hovercards/.markdownlint.json
+++ b/web/packages/hovercards/.markdownlint.json
@@ -13,7 +13,7 @@
 		"allow_different_nesting": true
 	},
 	"MD033": {
-		"allowed_elements": ["img"]
+		"allowed_elements": [ "img" ]
 	},
 	"MD041": false,
 	"no-hard-tabs": false,

--- a/web/packages/hovercards/.prettierrc.js
+++ b/web/packages/hovercards/.prettierrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-	...require('@wordpress/prettier-config'),
+	...require( '@wordpress/prettier-config' ),
 	printWidth: 120,
 };

--- a/web/packages/hovercards/.release-it.json
+++ b/web/packages/hovercards/.release-it.json
@@ -8,7 +8,7 @@
 	},
 	"github": {
 		"release": true,
-		"assets": ["release/hovercards.zip"]
+		"assets": [ "release/hovercards.zip" ]
 	},
 	"npm": {
 		"publish": true

--- a/web/packages/hovercards/babel.config.js
+++ b/web/packages/hovercards/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-	presets: [['@babel/env', { loose: true }], ['@babel/react', { runtime: 'automatic' }], '@babel/typescript'],
+	presets: [ [ '@babel/env', { loose: true } ], [ '@babel/react', { runtime: 'automatic' } ], '@babel/typescript' ],
 };

--- a/web/packages/hovercards/lint-staged.config.js
+++ b/web/packages/hovercards/lint-staged.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	'*.{js,jsx,ts,tsx}': [() => 'npm run type-check', 'npm run lint:js'],
+	'*.{js,jsx,ts,tsx}': [ () => 'npm run type-check', 'npm run lint:js' ],
 	'*.{css,scss}': 'npm run lint:style',
 	'*.md': 'npm run lint:md:docs',
 	'*.{js,jsx,ts,tsx,json,yaml,yml}': 'npm run format',

--- a/web/packages/hovercards/package.json
+++ b/web/packages/hovercards/package.json
@@ -60,7 +60,7 @@
 		"type-check": "tsc --noEmit",
 		"lint:js": "wp-scripts lint-js",
 		"lint:style": "wp-scripts lint-style",
-		"lint:md:docs": "wp-scripts lint-md-docs",
+		"lint:md": "wp-scripts lint-md-docs",
 		"lint": "run-p 'lint:*'",
 		"clean:dist": "rimraf dist",
 		"clean:release": "rimraf release",

--- a/web/packages/hovercards/playground/core.ts
+++ b/web/packages/hovercards/playground/core.ts
@@ -3,7 +3,7 @@
 import type { Options, Attach } from '../dist';
 import { Hovercards } from '../dist';
 
-addEventListener('DOMContentLoaded', () => {
+addEventListener( 'DOMContentLoaded', () => {
 	// To test types
 	const options: Options = {
 		placement: 'right',
@@ -13,23 +13,23 @@ addEventListener('DOMContentLoaded', () => {
 			'View profile': 'View profile 😜',
 		},
 	};
-	const hovercards = new Hovercards(options);
+	const hovercards = new Hovercards( options );
 
 	// To test type
-	const attach: Attach = (target, opts) => {
-		hovercards.attach(target, opts);
+	const attach: Attach = ( target, opts ) => {
+		hovercards.attach( target, opts );
 	};
-	attach(document.body, { ignoreSelector: '' });
+	attach( document.body, { ignoreSelector: '' } );
 
 	// To test sanitization
-	document.getElementById('inline-hovercard')?.appendChild(
-		Hovercards.createHovercard({
+	document.getElementById( 'inline-hovercard' )?.appendChild(
+		Hovercards.createHovercard( {
 			hash: '99c3338797c95c418d9996bd39931506',
 			avatarUrl: 'https://www.gravatar.com/avatar/99c3338797c95c418d9996bd39931506?s=60&d=retro&r=g&esc=^^',
 			profileUrl: 'https://gravatar.com/wellyshen',
 			displayName: '<i>gyp</i>',
 			location: '<i>Earth</i>',
 			description: '<i>Test</i>, &amp;, &lt;, &gt;, &quot;, &#39;, &#x60;',
-		})
+		} )
 	);
-});
+} );

--- a/web/packages/hovercards/playground/react.tsx
+++ b/web/packages/hovercards/playground/react.tsx
@@ -15,19 +15,19 @@ const props: HovercardsProps = {
 
 function App() {
 	// eslint-disable-next-line no-console
-	const { attach } = useHovercards({ onFetchProfileSuccess: (hash) => console.log(hash) });
-	const containerRef = useRef(null);
+	const { attach } = useHovercards( { onFetchProfileSuccess: ( hash ) => console.log( hash ) } );
+	const containerRef = useRef( null );
 
-	useEffect(() => {
-		if (containerRef.current) {
-			attach(containerRef.current);
+	useEffect( () => {
+		if ( containerRef.current ) {
+			attach( containerRef.current );
 		}
-	}, [attach]);
+	}, [ attach ] );
 
 	return (
-		<div style={{ display: 'flex', flexDirection: 'column', gap: '5rem' }}>
+		<div style={ { display: 'flex', flexDirection: 'column', gap: '5rem' } }>
 			<div>
-				<div ref={containerRef} style={{ display: 'flex', flexDirection: 'column', gap: '5rem' }}>
+				<div ref={ containerRef } style={ { display: 'flex', flexDirection: 'column', gap: '5rem' } }>
 					<img
 						src="https://www.gravatar.com/avatar/33252cd1f33526af53580fcb1736172f06e6716f32afdd1be19ec3096d15dea5?s=60&d=retro&r=g"
 						width="60"
@@ -42,7 +42,7 @@ function App() {
 					/>
 				</div>
 			</div>
-			<Hovercards style={{ display: 'flex', flexDirection: 'column', gap: '5rem' }} {...props}>
+			<Hovercards style={ { display: 'flex', flexDirection: 'column', gap: '5rem' } } { ...props }>
 				<img
 					src="https://www.gravatar.com/avatar/33252cd1f33526af53580fcb1736172f06e6716f32afdd1be19ec3096d15dea5?s=60&d=retro&r=g"
 					width="60"
@@ -66,5 +66,5 @@ function App() {
 	);
 }
 
-const root = createRoot(document.getElementById('react-app')!);
-root.render(<App />);
+const root = createRoot( document.getElementById( 'react-app' )! );
+root.render( <App /> );

--- a/web/packages/hovercards/postcss.config.js
+++ b/web/packages/hovercards/postcss.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	// Add you postcss configuration here
 	// Learn more about it at https://github.com/webpack-contrib/postcss-loader#config-files
-	plugins: [['autoprefixer']],
+	plugins: [ [ 'autoprefixer' ] ],
 };

--- a/web/packages/hovercards/src/compute-position.ts
+++ b/web/packages/hovercards/src/compute-position.ts
@@ -12,11 +12,11 @@ export type Placement =
 	| 'right-start'
 	| 'right-end';
 
-type Options = Partial<{
+type Options = Partial< {
 	placement: Placement;
 	offset: number;
 	autoFlip: boolean;
-}>;
+} >;
 
 interface ReturnValues {
 	x: number;
@@ -25,7 +25,7 @@ interface ReturnValues {
 	paddingValue: number;
 }
 
-const paddingMap: Record<string, ReturnValues['padding']> = {
+const paddingMap: Record< string, ReturnValues[ 'padding' ] > = {
 	top: 'paddingBottom',
 	bottom: 'paddingTop',
 	left: 'paddingRight',
@@ -53,12 +53,12 @@ export default function computingPosition(
 	const refScrollL = refRect.left + scrollX;
 	let x = 0;
 	let y = 0;
-	let [dir, align] = placement.split('-');
-	offset = Math.max(0, offset);
+	let [ dir, align ] = placement.split( '-' );
+	offset = Math.max( 0, offset );
 
 	// Auto flip the card if there's not enough space
 	// If both sides have not enough space, then the card will be placed on the side with more space
-	if (autoFlip) {
+	if ( autoFlip ) {
 		const topSpace = refRect.top;
 		const bottomSpace = innerHeight - refRect.bottom;
 		const leftSpace = refRect.left;
@@ -66,34 +66,34 @@ export default function computingPosition(
 		const floatingSpaceV = cardRect.height + offset;
 		const floatingSpaceH = cardRect.width + offset;
 
-		if (dir === 'top' && topSpace < floatingSpaceV && bottomSpace > topSpace) {
+		if ( dir === 'top' && topSpace < floatingSpaceV && bottomSpace > topSpace ) {
 			dir = 'bottom';
 		}
 
-		if (dir === 'bottom' && bottomSpace < floatingSpaceV && topSpace > bottomSpace) {
+		if ( dir === 'bottom' && bottomSpace < floatingSpaceV && topSpace > bottomSpace ) {
 			dir = 'top';
 		}
 
-		if (dir === 'left' && leftSpace < floatingSpaceH && rightSpace > leftSpace) {
+		if ( dir === 'left' && leftSpace < floatingSpaceH && rightSpace > leftSpace ) {
 			dir = 'right';
 		}
 
-		if (dir === 'right' && rightSpace < floatingSpaceH && leftSpace > rightSpace) {
+		if ( dir === 'right' && rightSpace < floatingSpaceH && leftSpace > rightSpace ) {
 			dir = 'left';
 		}
 	}
 
 	// Calculate the position of the card
-	if (dir === 'top' || dir === 'bottom') {
+	if ( dir === 'top' || dir === 'bottom' ) {
 		x = refScrollL + refRect.width / 2 - cardRect.width / 2;
 		// The bottom offset will be filled with the card's padding
 		y = dir === 'top' ? refScrollT - cardRect.height - offset : refScrollB;
 
-		if (align === 'start') {
+		if ( align === 'start' ) {
 			x = refScrollL;
 		}
 
-		if (align === 'end') {
+		if ( align === 'end' ) {
 			x = refScrollR - cardRect.width;
 		}
 	} else {
@@ -101,14 +101,14 @@ export default function computingPosition(
 		x = dir === 'right' ? refScrollR : refScrollL - cardRect.width - offset;
 		y = refScrollT + refRect.height / 2 - cardRect.height / 2;
 
-		if (align === 'start') {
+		if ( align === 'start' ) {
 			y = refScrollT;
 		}
 
-		if (align === 'end') {
+		if ( align === 'end' ) {
 			y = refScrollB - cardRect.height;
 		}
 	}
 
-	return { x, y, padding: paddingMap[dir], paddingValue: offset };
+	return { x, y, padding: paddingMap[ dir ], paddingValue: offset };
 }

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -3,9 +3,9 @@ import computePosition from './compute-position';
 import { escUrl, escHtml } from './sanitizer';
 import __ from './i18n';
 
-type AccountData = Record<'service_type' | 'service_label' | 'service_icon' | 'url', string>;
+type AccountData = Record< 'service_type' | 'service_label' | 'service_icon' | 'url', string >;
 
-export type VerifiedAccount = Record<'type' | 'label' | 'icon' | 'url', string>;
+export type VerifiedAccount = Record< 'type' | 'label' | 'icon' | 'url', string >;
 
 export interface ProfileData {
 	hash: string;
@@ -21,28 +21,28 @@ export interface ProfileData {
 
 export type CreateHovercard = (
 	profileData: ProfileData,
-	options?: { additionalClass?: string; myHash?: string; i18n?: Record<string, string> }
+	options?: { additionalClass?: string; myHash?: string; i18n?: Record< string, string > }
 ) => HTMLDivElement;
 
-export type Attach = (target: HTMLElement, options?: { dataAttributeName?: string; ignoreSelector?: string }) => void;
+export type Attach = ( target: HTMLElement, options?: { dataAttributeName?: string; ignoreSelector?: string } ) => void;
 
 export type Detach = () => void;
 
-export type OnQueryHovercardRef = (ref: HTMLElement) => HTMLElement;
+export type OnQueryHovercardRef = ( ref: HTMLElement ) => HTMLElement;
 
-export type OnFetchProfileStart = (hash: string) => void;
+export type OnFetchProfileStart = ( hash: string ) => void;
 
-export type OnFetchProfileSuccess = (hash: string, profileData: ProfileData) => void;
+export type OnFetchProfileSuccess = ( hash: string, profileData: ProfileData ) => void;
 
 export type FetchProfileError = { code: number; message: string };
 
-export type OnFetchProfileFailure = (hash: string, error: FetchProfileError) => void;
+export type OnFetchProfileFailure = ( hash: string, error: FetchProfileError ) => void;
 
-export type OnHovercardShown = (hash: string, hovercard: HTMLDivElement) => void;
+export type OnHovercardShown = ( hash: string, hovercard: HTMLDivElement ) => void;
 
-export type OnHovercardHidden = (hash: string, hovercard: HTMLDivElement) => void;
+export type OnHovercardHidden = ( hash: string, hovercard: HTMLDivElement ) => void;
 
-export type Options = Partial<{
+export type Options = Partial< {
 	placement: Placement;
 	offset: number;
 	autoFlip: boolean;
@@ -50,14 +50,14 @@ export type Options = Partial<{
 	delayToHide: number;
 	additionalClass: string;
 	myHash: string;
-	i18n: Record<string, string>;
+	i18n: Record< string, string >;
 	onQueryHovercardRef: OnQueryHovercardRef;
 	onFetchProfileStart: OnFetchProfileStart;
 	onFetchProfileSuccess: OnFetchProfileSuccess;
 	onFetchProfileFailure: OnFetchProfileFailure;
 	onHovercardShown: OnHovercardShown;
 	onHovercardHidden: OnHovercardHidden;
-}>;
+} >;
 
 interface HovercardRef {
 	id: string;
@@ -85,15 +85,15 @@ export default class Hovercards {
 	_onFetchProfileFailure: OnFetchProfileFailure;
 	_onHovercardShown: OnHovercardShown;
 	_onHovercardHidden: OnHovercardHidden;
-	_i18n: Record<string, string> = {};
+	_i18n: Record< string, string > = {};
 
 	// Variables
 	_hovercardRefs: HovercardRef[] = [];
-	_showHovercardTimeoutIds = new Map<string, ReturnType<typeof setTimeout>>();
-	_hideHovercardTimeoutIds = new Map<string, ReturnType<typeof setTimeout>>();
-	_cachedProfiles = new Map<string, ProfileData>();
+	_showHovercardTimeoutIds = new Map< string, ReturnType< typeof setTimeout > >();
+	_hideHovercardTimeoutIds = new Map< string, ReturnType< typeof setTimeout > >();
+	_cachedProfiles = new Map< string, ProfileData >();
 
-	constructor({
+	constructor( {
 		placement = 'right',
 		autoFlip = true,
 		offset = 10,
@@ -101,14 +101,14 @@ export default class Hovercards {
 		delayToHide = 300,
 		additionalClass = '',
 		myHash = '',
-		onQueryHovercardRef = (ref) => ref,
+		onQueryHovercardRef = ( ref ) => ref,
 		onFetchProfileStart = () => {},
 		onFetchProfileSuccess = () => {},
 		onFetchProfileFailure = () => {},
 		onHovercardShown = () => {},
 		onHovercardHidden = () => {},
 		i18n = {},
-	}: Options = {}) {
+	}: Options = {} ) {
 		this._placement = placement;
 		this._autoFlip = autoFlip;
 		this._offset = offset;
@@ -134,65 +134,65 @@ export default class Hovercards {
 	 * @return {HTMLElement[]}                - The queried hovercard refs.
 	 * @private
 	 */
-	_queryHovercardRefs(target: HTMLElement, dataAttributeName: string, ignoreSelector?: string) {
+	_queryHovercardRefs( target: HTMLElement, dataAttributeName: string, ignoreSelector?: string ) {
 		let refs: HTMLElement[] = [];
-		const camelAttrName = dataAttributeName.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
-		const ignoreRefs = ignoreSelector ? Array.from(dc.querySelectorAll(ignoreSelector)) : [];
+		const camelAttrName = dataAttributeName.replace( /-([a-z])/g, ( g ) => g[ 1 ].toUpperCase() );
+		const ignoreRefs = ignoreSelector ? Array.from( dc.querySelectorAll( ignoreSelector ) ) : [];
 		const matchPath = 'gravatar.com/avatar/';
 
 		if (
-			(camelAttrName && target.dataset[camelAttrName]) ||
-			(target.tagName === 'IMG' && (target as HTMLImageElement).src.includes(matchPath))
+			( camelAttrName && target.dataset[ camelAttrName ] ) ||
+			( target.tagName === 'IMG' && ( target as HTMLImageElement ).src.includes( matchPath ) )
 		) {
-			refs = [target];
+			refs = [ target ];
 		} else {
-			refs = Array.from(target.querySelectorAll(`img[src*="${matchPath}"]`));
+			refs = Array.from( target.querySelectorAll( `img[src*="${ matchPath }"]` ) );
 
-			if (dataAttributeName) {
+			if ( dataAttributeName ) {
 				refs = [
 					// Filter out images that already have the data attribute
-					...refs.filter((img) => !img.hasAttribute(`data-${dataAttributeName}`)),
-					...Array.from<HTMLElement>(target.querySelectorAll(`[data-${dataAttributeName}]`)),
+					...refs.filter( ( img ) => ! img.hasAttribute( `data-${ dataAttributeName }` ) ),
+					...Array.from< HTMLElement >( target.querySelectorAll( `[data-${ dataAttributeName }]` ) ),
 				];
 			}
 		}
 
 		this._hovercardRefs = refs
-			.map((ref, idx) => {
-				if (ignoreRefs.includes(ref)) {
+			.map( ( ref, idx ) => {
+				if ( ignoreRefs.includes( ref ) ) {
 					return null;
 				}
 
 				let hash;
 				let params;
-				const dataAttrValue = ref.dataset[camelAttrName];
+				const dataAttrValue = ref.dataset[ camelAttrName ];
 
-				if (dataAttrValue) {
-					hash = dataAttrValue.split('?')[0];
+				if ( dataAttrValue ) {
+					hash = dataAttrValue.split( '?' )[ 0 ];
 					params = dataAttrValue;
-				} else if (ref.tagName === 'IMG') {
-					hash = (ref as HTMLImageElement).src.split('/').pop().split('?')[0];
-					params = (ref as HTMLImageElement).src;
+				} else if ( ref.tagName === 'IMG' ) {
+					hash = ( ref as HTMLImageElement ).src.split( '/' ).pop().split( '?' )[ 0 ];
+					params = ( ref as HTMLImageElement ).src;
 				}
 
-				if (!hash) {
+				if ( ! hash ) {
 					return null;
 				}
 
-				const p = new URLSearchParams(params);
-				const d = p.get('d') || p.get('default');
-				const f = p.get('f') || p.get('forcedefault');
-				const r = p.get('r') || p.get('rating');
-				params = [d && `d=${d}`, f && `f=${f}`, r && `r=${r}`].filter(Boolean).join('&');
+				const p = new URLSearchParams( params );
+				const d = p.get( 'd' ) || p.get( 'default' );
+				const f = p.get( 'f' ) || p.get( 'forcedefault' );
+				const r = p.get( 'r' ) || p.get( 'rating' );
+				params = [ d && `d=${ d }`, f && `f=${ f }`, r && `r=${ r }` ].filter( Boolean ).join( '&' );
 
 				return {
-					id: `gravatar-hovercard-${hash}-${idx}`,
+					id: `gravatar-hovercard-${ hash }-${ idx }`,
 					hash,
-					params: params ? `?${params}` : '',
-					ref: this._onQueryHovercardRef(ref) || ref,
+					params: params ? `?${ params }` : '',
+					ref: this._onQueryHovercardRef( ref ) || ref,
 				};
-			})
-			.filter(Boolean);
+			} )
+			.filter( Boolean );
 
 		return this._hovercardRefs;
 	}
@@ -203,9 +203,9 @@ export default class Hovercards {
 	 * @return {HTMLDivElement} The created skeleton hovercard element.
 	 */
 	_createHovercardSkeleton() {
-		const hovercard = dc.createElement('div');
+		const hovercard = dc.createElement( 'div' );
 		hovercard.className = `gravatar-hovercard gravatar-hovercard--skeleton${
-			this._additionalClass ? ` ${this._additionalClass}` : ''
+			this._additionalClass ? ` ${ this._additionalClass }` : ''
 		}`;
 
 		hovercard.innerHTML = `
@@ -234,7 +234,7 @@ export default class Hovercards {
 	 * @param {Object}      [options.i18n]            - The i18n object.
 	 * @return {HTMLDivElement}                       - The created hovercard element.
 	 */
-	static createHovercard: CreateHovercard = (profileData, { additionalClass, myHash, i18n = {} } = {}) => {
+	static createHovercard: CreateHovercard = ( profileData, { additionalClass, myHash, i18n = {} } = {} ) => {
 		const {
 			hash,
 			avatarUrl,
@@ -247,56 +247,58 @@ export default class Hovercards {
 			verifiedAccounts = [],
 		} = profileData;
 
-		const hovercard = dc.createElement('div');
-		hovercard.className = `gravatar-hovercard${additionalClass ? ` ${additionalClass}` : ''}`;
+		const hovercard = dc.createElement( 'div' );
+		hovercard.className = `gravatar-hovercard${ additionalClass ? ` ${ additionalClass }` : '' }`;
 
-		const trackedProfileUrl = escUrl(`${profileUrl}?utm_source=hovercard`);
-		const username = escHtml(displayName);
-		const isEditProfile = !description && myHash === hash;
+		const trackedProfileUrl = escUrl( `${ profileUrl }?utm_source=hovercard` );
+		const username = escHtml( displayName );
+		const isEditProfile = ! description && myHash === hash;
 		const renderSocialLinks = verifiedAccounts
-			.slice(0, 3)
-			.reduce((links, { label, icon, url, type }) => {
-				links.push(`
-					<a class="gravatar-hovercard__social-link" href="${escUrl(url)}" target="_blank" data-service-name="${type}">
-						<img class="gravatar-hovercard__social-icon" src="${escUrl(icon)}" width="32" height="32" alt="${escHtml(label)}" />
+			.slice( 0, 3 )
+			.reduce( ( links, { label, icon, url, type } ) => {
+				links.push( `
+					<a class="gravatar-hovercard__social-link" href="${ escUrl( url ) }" target="_blank" data-service-name="${ type }">
+						<img class="gravatar-hovercard__social-icon" src="${ escUrl( icon ) }" width="32" height="32" alt="${ escHtml(
+							label
+						) }" />
 					</a>
-				`);
+				` );
 
 				return links;
-			}, [])
-			.join('');
+			}, [] )
+			.join( '' );
 
-		const jobInfo = [jobTitle, company].filter(Boolean).join(', ');
+		const jobInfo = [ jobTitle, company ].filter( Boolean ).join( ', ' );
 
 		hovercard.innerHTML = `
 			<div class="gravatar-hovercard__inner">
 				<div class="gravatar-hovercard__header">
-					<a class="gravatar-hovercard__avatar-link" href="${trackedProfileUrl}" target="_blank">
-						<img class="gravatar-hovercard__avatar" src="${escUrl(avatarUrl)}" width="72" height="72" alt="${username}" />
+					<a class="gravatar-hovercard__avatar-link" href="${ trackedProfileUrl }" target="_blank">
+						<img class="gravatar-hovercard__avatar" src="${ escUrl( avatarUrl ) }" width="72" height="72" alt="${ username }" />
 					</a>
-					<a class="gravatar-hovercard__personal-info-link" href="${trackedProfileUrl}" target="_blank">
-						<h4 class="gravatar-hovercard__name">${username}</h4>
-						${jobInfo ? `<p class="gravatar-hovercard__job">${escHtml(jobInfo)}</p>` : ''}
-						${location ? `<p class="gravatar-hovercard__location">${escHtml(location)}</p>` : ''}
+					<a class="gravatar-hovercard__personal-info-link" href="${ trackedProfileUrl }" target="_blank">
+						<h4 class="gravatar-hovercard__name">${ username }</h4>
+						${ jobInfo ? `<p class="gravatar-hovercard__job">${ escHtml( jobInfo ) }</p>` : '' }
+						${ location ? `<p class="gravatar-hovercard__location">${ escHtml( location ) }</p>` : '' }
 					</a>
 				</div>
 				<div class="gravatar-hovercard__body">
-					${description ? `<p class="gravatar-hovercard__description">${escHtml(description)}</p>` : ''}
+					${ description ? `<p class="gravatar-hovercard__description">${ escHtml( description ) }</p>` : '' }
 				</div>
 				<div class="gravatar-hovercard__footer">
 					<div class="gravatar-hovercard__social-links">
-						<a class="gravatar-hovercard__social-link" href="${trackedProfileUrl}" target="_blank" data-service-name="gravatar">
+						<a class="gravatar-hovercard__social-link" href="${ trackedProfileUrl }" target="_blank" data-service-name="gravatar">
 							<img class="gravatar-hovercard__social-icon" src="https://secure.gravatar.com/icons/gravatar.svg" width="32" height="32" alt="Gravatar" />
 						</a>
-						${renderSocialLinks}
+						${ renderSocialLinks }
 					</div>
 					<a
-						class="gravatar-hovercard__profile-link${isEditProfile ? ' gravatar-hovercard__profile-link--edit' : ''}"
-						href="${isEditProfile ? 'https://gravatar.com/profiles/edit?utm_source=hovercard' : trackedProfileUrl}"
+						class="gravatar-hovercard__profile-link${ isEditProfile ? ' gravatar-hovercard__profile-link--edit' : '' }"
+						href="${ isEditProfile ? 'https://gravatar.com/profiles/edit?utm_source=hovercard' : trackedProfileUrl }"
 						target="_blank"
 					>
 						<span class="gravatar-hovercard__profile-link-text">
-							${isEditProfile ? __(i18n, 'Edit your profile') : __(i18n, 'View profile')}
+							${ isEditProfile ? __( i18n, 'Edit your profile' ) : __( i18n, 'View profile' ) }
 						</span>
 						<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
 							<path d="M12.6667 8.33338L9.16666 12.1667M12.6667 8.33338L2.66666 8.33338M12.6667 8.33338L9.16666 4.83338" stroke-width="1.5"/>
@@ -317,16 +319,16 @@ export default class Hovercards {
 	 * @return {void}
 	 * @private
 	 */
-	_showHovercard({ id, hash, params, ref }: HovercardRef) {
-		const timeoutId = setTimeout(() => {
-			if (dc.getElementById(id)) {
+	_showHovercard( { id, hash, params, ref }: HovercardRef ) {
+		const timeoutId = setTimeout( () => {
+			if ( dc.getElementById( id ) ) {
 				return;
 			}
 
 			let hovercard: HTMLDivElement;
 
-			if (this._cachedProfiles.has(hash)) {
-				const profile = this._cachedProfiles.get(hash);
+			if ( this._cachedProfiles.has( hash ) ) {
+				const profile = this._cachedProfiles.get( hash );
 
 				hovercard = Hovercards.createHovercard(
 					{ ...profile, avatarUrl: profile.avatarUrl + params },
@@ -339,19 +341,19 @@ export default class Hovercards {
 			} else {
 				hovercard = this._createHovercardSkeleton();
 
-				this._onFetchProfileStart(hash);
+				this._onFetchProfileStart( hash );
 
-				fetch(`${BASE_API_URL}/${hash}?source=hovercard`)
-					.then((res) => {
+				fetch( `${ BASE_API_URL }/${ hash }?source=hovercard` )
+					.then( ( res ) => {
 						// API error handling
-						if (res.status !== 200) {
+						if ( res.status !== 200 ) {
 							throw res.status;
 						}
 
 						return res.json();
-					})
-					.then((data) => {
-						this._cachedProfiles.set(hash, {
+					} )
+					.then( ( data ) => {
+						this._cachedProfiles.set( hash, {
 							hash: data.hash,
 							avatarUrl: data.avatar_url,
 							profileUrl: data.profile_url,
@@ -360,15 +362,15 @@ export default class Hovercards {
 							description: data.description,
 							jobTitle: data.job_title,
 							company: data.company,
-							verifiedAccounts: data.verified_accounts?.map((account: AccountData) => ({
+							verifiedAccounts: data.verified_accounts?.map( ( account: AccountData ) => ( {
 								type: account.service_type,
 								label: account.service_label,
 								icon: account.service_icon,
 								url: account.url,
-							})),
-						});
+							} ) ),
+						} );
 
-						const profile = this._cachedProfiles.get(hash);
+						const profile = this._cachedProfiles.get( hash );
 						const hovercardInner = Hovercards.createHovercard(
 							{ ...profile, avatarUrl: profile.avatarUrl + params },
 							{
@@ -378,58 +380,58 @@ export default class Hovercards {
 							}
 						).firstElementChild;
 
-						hovercard.classList.remove('gravatar-hovercard--skeleton');
-						hovercard.replaceChildren(hovercardInner);
+						hovercard.classList.remove( 'gravatar-hovercard--skeleton' );
+						hovercard.replaceChildren( hovercardInner );
 
-						this._onFetchProfileSuccess(hash, this._cachedProfiles.get(hash));
-					})
-					.catch((code) => {
-						let message = __(this._i18n, 'Sorry, we are unable to load this Gravatar profile.');
+						this._onFetchProfileSuccess( hash, this._cachedProfiles.get( hash ) );
+					} )
+					.catch( ( code ) => {
+						let message = __( this._i18n, 'Sorry, we are unable to load this Gravatar profile.' );
 
-						if (code === 429) {
-							message = __(this._i18n, 'Too Many Requests.');
+						if ( code === 429 ) {
+							message = __( this._i18n, 'Too Many Requests.' );
 						}
 
-						if (code === 500) {
-							message = __(this._i18n, 'Internal Server Error.');
+						if ( code === 500 ) {
+							message = __( this._i18n, 'Internal Server Error.' );
 						}
 
-						hovercard.firstElementChild.classList.add('gravatar-hovercard__inner--error');
+						hovercard.firstElementChild.classList.add( 'gravatar-hovercard__inner--error' );
 						hovercard.firstElementChild.innerHTML = `
-							<img class="gravatar-hovercard__avatar" src="https://2.gravatar.com/avatar/${hash}${params}" width="72" height="72" alt="Avatar" />
-							<i class="gravatar-hovercard__error-message">${message}</i>
+							<img class="gravatar-hovercard__avatar" src="https://2.gravatar.com/avatar/${ hash }${ params }" width="72" height="72" alt="Avatar" />
+							<i class="gravatar-hovercard__error-message">${ message }</i>
 						`;
 
-						this._onFetchProfileFailure(hash, { code, message });
-					});
+						this._onFetchProfileFailure( hash, { code, message } );
+					} );
 			}
 
 			// Set the hovercard ID here to avoid the show / hide side effect
 			hovercard.id = id;
 			// Don't hide the hovercard when the mouse is over the hovercard from the ref
-			hovercard.addEventListener('mouseenter', () => clearInterval(this._hideHovercardTimeoutIds.get(id)));
-			hovercard.addEventListener('mouseleave', () => this._hideHovercard(id));
+			hovercard.addEventListener( 'mouseenter', () => clearInterval( this._hideHovercardTimeoutIds.get( id ) ) );
+			hovercard.addEventListener( 'mouseleave', () => this._hideHovercard( id ) );
 
 			// Placing the hovercard at the top-level of the dc to avoid being clipped by overflow
-			dc.body.appendChild(hovercard);
+			dc.body.appendChild( hovercard );
 
-			const { x, y, padding, paddingValue } = computePosition(ref, hovercard, {
+			const { x, y, padding, paddingValue } = computePosition( ref, hovercard, {
 				placement: this._placement,
 				offset: this._offset,
 				autoFlip: this._autoFlip,
-			});
+			} );
 
 			hovercard.style.position = 'absolute';
-			hovercard.style.left = `${x}px`;
-			hovercard.style.top = `${y}px`;
+			hovercard.style.left = `${ x }px`;
+			hovercard.style.top = `${ y }px`;
 			// To bridge the gap between the ref and the hovercard,
 			// ensuring that the hovercard remains visible when the mouse hovers over the gap
-			hovercard.style[padding] = `${paddingValue}px`;
+			hovercard.style[ padding ] = `${ paddingValue }px`;
 
-			this._onHovercardShown(hash, hovercard);
-		}, this._delayToShow);
+			this._onHovercardShown( hash, hovercard );
+		}, this._delayToShow );
 
-		this._showHovercardTimeoutIds.set(id, timeoutId);
+		this._showHovercardTimeoutIds.set( id, timeoutId );
 	}
 
 	/**
@@ -439,17 +441,17 @@ export default class Hovercards {
 	 * @return {void}
 	 * @private
 	 */
-	_hideHovercard(id: string) {
-		const timeoutId = setTimeout(() => {
-			const hovercard = dc.getElementById(id);
+	_hideHovercard( id: string ) {
+		const timeoutId = setTimeout( () => {
+			const hovercard = dc.getElementById( id );
 
-			if (hovercard) {
+			if ( hovercard ) {
 				hovercard.remove();
-				this._onHovercardHidden(id, hovercard as HTMLDivElement);
+				this._onHovercardHidden( id, hovercard as HTMLDivElement );
 			}
-		}, this._delayToHide);
+		}, this._delayToHide );
 
-		this._hideHovercardTimeoutIds.set(id, timeoutId);
+		this._hideHovercardTimeoutIds.set( id, timeoutId );
 	}
 
 	/**
@@ -460,16 +462,16 @@ export default class Hovercards {
 	 * @return {void}
 	 * @private
 	 */
-	_handleMouseEnter(e: MouseEvent, hovercardRef: HovercardRef) {
-		if ('ontouchstart' in dc) {
+	_handleMouseEnter( e: MouseEvent, hovercardRef: HovercardRef ) {
+		if ( 'ontouchstart' in dc ) {
 			return;
 		}
 
 		e.stopImmediatePropagation();
 
 		// Don't hide the hovercard when the mouse is over the ref from the hovercard
-		clearInterval(this._hideHovercardTimeoutIds.get(hovercardRef.id));
-		this._showHovercard(hovercardRef);
+		clearInterval( this._hideHovercardTimeoutIds.get( hovercardRef.id ) );
+		this._showHovercard( hovercardRef );
 	}
 
 	/**
@@ -481,15 +483,15 @@ export default class Hovercards {
 	 * @return {void}
 	 * @private
 	 */
-	_handleMouseLeave(e: MouseEvent, { id }: HovercardRef) {
-		if ('ontouchstart' in dc) {
+	_handleMouseLeave( e: MouseEvent, { id }: HovercardRef ) {
+		if ( 'ontouchstart' in dc ) {
 			return;
 		}
 
 		e.stopImmediatePropagation();
 
-		clearInterval(this._showHovercardTimeoutIds.get(id));
-		this._hideHovercard(id);
+		clearInterval( this._showHovercardTimeoutIds.get( id ) );
+		this._hideHovercard( id );
 	}
 
 	/**
@@ -501,17 +503,17 @@ export default class Hovercards {
 	 * @param               options.ignoreSelector    - The selector to ignore certain elements.
 	 * @return {void}
 	 */
-	attach: Attach = (target, { dataAttributeName = 'gravatar-hash', ignoreSelector } = {}) => {
-		if (!target) {
+	attach: Attach = ( target, { dataAttributeName = 'gravatar-hash', ignoreSelector } = {} ) => {
+		if ( ! target ) {
 			return;
 		}
 
 		this.detach();
 
-		this._queryHovercardRefs(target, dataAttributeName, ignoreSelector).forEach((hovercardRef) => {
-			hovercardRef.ref.addEventListener('mouseenter', (e) => this._handleMouseEnter(e, hovercardRef));
-			hovercardRef.ref.addEventListener('mouseleave', (e) => this._handleMouseLeave(e, hovercardRef));
-		});
+		this._queryHovercardRefs( target, dataAttributeName, ignoreSelector ).forEach( ( hovercardRef ) => {
+			hovercardRef.ref.addEventListener( 'mouseenter', ( e ) => this._handleMouseEnter( e, hovercardRef ) );
+			hovercardRef.ref.addEventListener( 'mouseleave', ( e ) => this._handleMouseLeave( e, hovercardRef ) );
+		} );
 	};
 
 	/**
@@ -520,14 +522,14 @@ export default class Hovercards {
 	 * @return {void}
 	 */
 	detach: Detach = () => {
-		if (!this._hovercardRefs.length) {
+		if ( ! this._hovercardRefs.length ) {
 			return;
 		}
 
-		this._hovercardRefs.forEach(({ ref }) => {
-			ref.removeEventListener('mouseenter', () => this._handleMouseEnter);
-			ref.removeEventListener('mouseleave', () => this._handleMouseLeave);
-		});
+		this._hovercardRefs.forEach( ( { ref } ) => {
+			ref.removeEventListener( 'mouseenter', () => this._handleMouseEnter );
+			ref.removeEventListener( 'mouseleave', () => this._handleMouseLeave );
+		} );
 
 		this._hovercardRefs = [];
 	};

--- a/web/packages/hovercards/src/hovercards.tsx
+++ b/web/packages/hovercards/src/hovercards.tsx
@@ -6,16 +6,16 @@ import useLatest from './use-latest';
 import useHovercards from './use-hovercards';
 
 export type HovercardsProps = Options &
-	Partial<{
+	Partial< {
 		children: ReactNode;
 		attach: HTMLElement;
 		dataAttributeName: string;
 		ignoreSelector: string;
 		className: string;
 		style: CSSProperties;
-	}>;
+	} >;
 
-export default function Hovercards({
+export default function Hovercards( {
 	children,
 	attach,
 	dataAttributeName,
@@ -23,26 +23,26 @@ export default function Hovercards({
 	className,
 	style,
 	...options
-}: HovercardsProps = {}) {
-	const { attach: attachTo } = useHovercards(options);
-	const containerRef = useRef(null);
-	const attachRef = useLatest(attach);
+}: HovercardsProps = {} ) {
+	const { attach: attachTo } = useHovercards( options );
+	const containerRef = useRef( null );
+	const attachRef = useLatest( attach );
 
-	useEffect(() => {
+	useEffect( () => {
 		const target = attachRef.current || containerRef.current;
 
-		if (target) {
-			attachTo(target, { dataAttributeName, ignoreSelector });
+		if ( target ) {
+			attachTo( target, { dataAttributeName, ignoreSelector } );
 		}
-	}, [attachTo, attachRef, dataAttributeName, ignoreSelector]);
+	}, [ attachTo, attachRef, dataAttributeName, ignoreSelector ] );
 
-	if (attach || !children) {
+	if ( attach || ! children ) {
 		return null;
 	}
 
 	return (
-		<div ref={containerRef} className={className} style={style}>
-			{children}
+		<div ref={ containerRef } className={ className } style={ style }>
+			{ children }
 		</div>
 	);
 }

--- a/web/packages/hovercards/src/i18n.ts
+++ b/web/packages/hovercards/src/i18n.ts
@@ -1,3 +1,3 @@
-export default function __(i18n: Record<string, string>, key: string) {
-	return i18n[key] || key;
+export default function __( i18n: Record< string, string >, key: string ) {
+	return i18n[ key ] || key;
 }

--- a/web/packages/hovercards/src/sanitizer.ts
+++ b/web/packages/hovercards/src/sanitizer.ts
@@ -1,5 +1,5 @@
-export function escHtml(str: string) {
-	const htmlEntities: Record<string, string> = {
+export function escHtml( str: string ) {
+	const htmlEntities: Record< string, string > = {
 		'&': '&amp;',
 		'<': '&lt;',
 		'>': '&gt;',
@@ -9,11 +9,11 @@ export function escHtml(str: string) {
 	};
 
 	// Don't escape if already escaped.
-	return str.replace(/&(amp|lt|gt|quot|#39|x60);|[\&<>"'`]/g, (match) =>
-		match[0] === '&' ? match : htmlEntities[match]
+	return str.replace( /&(amp|lt|gt|quot|#39|x60);|[\&<>"'`]/g, ( match ) =>
+		match[ 0 ] === '&' ? match : htmlEntities[ match ]
 	);
 }
 
-export function escUrl(url: string) {
-	return encodeURI(url);
+export function escUrl( url: string ) {
+	return encodeURI( url );
 }

--- a/web/packages/hovercards/src/use-hovercards.ts
+++ b/web/packages/hovercards/src/use-hovercards.ts
@@ -10,7 +10,7 @@ export interface UseHovercardsReturnValues {
 	createHovercard: CreateHovercard;
 }
 
-export default function useHovercards({
+export default function useHovercards( {
 	placement,
 	offset,
 	autoFlip,
@@ -25,19 +25,19 @@ export default function useHovercards({
 	onFetchProfileFailure,
 	onHovercardShown,
 	onHovercardHidden,
-}: Options = {}): UseHovercardsReturnValues {
+}: Options = {} ): UseHovercardsReturnValues {
 	// These callbacks / variables won't trigger hooks update and will always be the latest
-	const onQueryHovercardRefRef = useLatest(onQueryHovercardRef);
-	const onFetchProfileStartRef = useLatest(onFetchProfileStart);
-	const onFetchProfileSuccessRef = useLatest(onFetchProfileSuccess);
-	const onFetchProfileFailureRef = useLatest(onFetchProfileFailure);
-	const onHovercardShownRef = useLatest(onHovercardShown);
-	const onHovercardHiddenRef = useLatest(onHovercardHidden);
-	const i18nRef = useLatest(i18n);
+	const onQueryHovercardRefRef = useLatest( onQueryHovercardRef );
+	const onFetchProfileStartRef = useLatest( onFetchProfileStart );
+	const onFetchProfileSuccessRef = useLatest( onFetchProfileSuccess );
+	const onFetchProfileFailureRef = useLatest( onFetchProfileFailure );
+	const onHovercardShownRef = useLatest( onHovercardShown );
+	const onHovercardHiddenRef = useLatest( onHovercardHidden );
+	const i18nRef = useLatest( i18n );
 	// Instantiate the Hovercards class only when the options change
 	const { attach, detach } = useMemo(
 		() =>
-			new Hovercards({
+			new Hovercards( {
 				placement,
 				offset,
 				autoFlip,
@@ -52,7 +52,7 @@ export default function useHovercards({
 				onFetchProfileFailure: onFetchProfileFailureRef.current,
 				onHovercardShown: onHovercardShownRef.current,
 				onHovercardHidden: onHovercardHiddenRef.current,
-			}),
+			} ),
 		[
 			placement,
 			offset,
@@ -71,9 +71,9 @@ export default function useHovercards({
 		]
 	);
 
-	useEffect(() => {
+	useEffect( () => {
 		return detach;
-	}, [detach]);
+	}, [ detach ] );
 
 	return { attach, detach, createHovercard: Hovercards.createHovercard };
 }

--- a/web/packages/hovercards/src/use-latest.ts
+++ b/web/packages/hovercards/src/use-latest.ts
@@ -8,8 +8,8 @@ import { MutableRefObject, useRef } from 'react';
  * @return {MutableRefObject<T>} Mutable reference object initialized to `val`.
  * @internal
  */
-export default <T>(val: T): MutableRefObject<T> => {
-	const ref = useRef(val);
+export default < T >( val: T ): MutableRefObject< T > => {
+	const ref = useRef( val );
 	ref.current = val;
 	return ref;
 };

--- a/web/packages/hovercards/tsconfig.json
+++ b/web/packages/hovercards/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig",
 	"compilerOptions": {
-		"lib": ["dom", "dom.iterable", "esnext"],
+		"lib": [ "dom", "dom.iterable", "esnext" ],
 		"jsx": "react-jsx",
 		"esModuleInterop": true,
 		"allowSyntheticDefaultImports": true,
@@ -15,6 +15,6 @@
 		"stripInternal": true,
 		"outDir": "dist"
 	},
-	"include": ["src"],
-	"exclude": ["node_modules"]
+	"include": [ "src" ],
+	"exclude": [ "node_modules" ]
 }

--- a/web/packages/hovercards/webpack/config.common.js
+++ b/web/packages/hovercards/webpack/config.common.js
@@ -1,41 +1,41 @@
-const path = require('path');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const RemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts');
-const TerserPlugin = require('terser-webpack-plugin');
+const path = require( 'path' );
+const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
+const RemoveEmptyScriptsPlugin = require( 'webpack-remove-empty-scripts' );
+const TerserPlugin = require( 'terser-webpack-plugin' );
 
 const isProduction = process.env.NODE_ENV === 'production';
 
 module.exports = {
-	context: path.resolve(__dirname, '..'),
+	context: path.resolve( __dirname, '..' ),
 	mode: isProduction ? 'production' : 'development',
 	devtool: isProduction ? 'source-map' : 'eval-source-map',
 	optimization: {
 		minimizer: [
-			new TerserPlugin({
+			new TerserPlugin( {
 				extractComments: false,
 				terserOptions: {
 					format: {
 						comments: false,
 					},
 				},
-			}),
+			} ),
 		],
 	},
-	plugins: [new RemoveEmptyScriptsPlugin(), new MiniCssExtractPlugin()],
+	plugins: [ new RemoveEmptyScriptsPlugin(), new MiniCssExtractPlugin() ],
 	module: {
 		rules: [
 			{
 				test: /\.(jsx?|tsx?)$/i,
 				loader: 'babel-loader',
-				exclude: ['/node_modules/'],
+				exclude: [ '/node_modules/' ],
 			},
 			{
 				test: /\.s[ac]ss$/i,
-				use: [MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader', 'sass-loader'],
+				use: [ MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader', 'sass-loader' ],
 			},
 			{
 				test: /\.css$/i,
-				use: [MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader'],
+				use: [ MiniCssExtractPlugin.loader, 'css-loader', 'postcss-loader' ],
 			},
 			{
 				test: /\.(eot|svg|ttf|woff|woff2|png|jpg|gif)$/i,
@@ -44,6 +44,6 @@ module.exports = {
 		],
 	},
 	resolve: {
-		extensions: ['.tsx', '.ts', '.jsx', '.js', '.mjs'],
+		extensions: [ '.tsx', '.ts', '.jsx', '.js', '.mjs' ],
 	},
 };

--- a/web/packages/hovercards/webpack/config.core.js
+++ b/web/packages/hovercards/webpack/config.core.js
@@ -1,12 +1,12 @@
-const path = require('path');
+const path = require( 'path' );
 
-const commonConfig = require('./config.common');
+const commonConfig = require( './config.common' );
 
 const baseConfig = {
 	...commonConfig,
 	entry: './src/index.ts',
 	output: {
-		path: path.resolve('dist'),
+		path: path.resolve( 'dist' ),
 	},
 };
 
@@ -72,4 +72,4 @@ const styleConfig = {
 	},
 };
 
-module.exports = [cjsConfig, esmConfig, mjsConfig, umdConfig, styleConfig];
+module.exports = [ cjsConfig, esmConfig, mjsConfig, umdConfig, styleConfig ];

--- a/web/packages/hovercards/webpack/config.playground.js
+++ b/web/packages/hovercards/webpack/config.playground.js
@@ -1,18 +1,18 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
 
-const commonConfig = require('./config.common');
+const commonConfig = require( './config.common' );
 
 module.exports = {
 	...commonConfig,
 	entry: './playground/index.ts',
 	devServer: {
 		open: true,
-		watchFiles: ['playground'],
+		watchFiles: [ 'playground' ],
 	},
 	plugins: [
 		...commonConfig.plugins,
-		new HtmlWebpackPlugin({
+		new HtmlWebpackPlugin( {
 			template: './playground/index.html',
-		}),
+		} ),
 	],
 };

--- a/web/packages/hovercards/webpack/config.react.js
+++ b/web/packages/hovercards/webpack/config.react.js
@@ -1,12 +1,12 @@
-const path = require('path');
+const path = require( 'path' );
 
-const commonConfig = require('./config.common');
+const commonConfig = require( './config.common' );
 
 const baseConfig = {
 	...commonConfig,
 	entry: './src/index.react.ts',
 	output: {
-		path: path.resolve('dist'),
+		path: path.resolve( 'dist' ),
 	},
 	externals: {
 		react: 'react',
@@ -65,4 +65,4 @@ const umdConfig = {
 	},
 };
 
-module.exports = [cjsConfig, mjsConfig, umdConfig];
+module.exports = [ cjsConfig, mjsConfig, umdConfig ];


### PR DESCRIPTION
## Proposed Changes

This PR reformats the hovercard files to comply with the latest linter settings.

With that, I believe https://github.com/Automattic/gravatar/issues/20 can be closed.

## Testing Instructions

* Checkout this branch
* Make sure the node_modules are up to date running `npm install`
* Still in the terminal, navigate to the hovercards folder: `cd web/packages/hovercards`
* Run `npm run lint`
* There shouldn't be any lint errors
