### PR TITLE
Export more hovercards status methods

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,10 +1,11 @@
 #!/bin/sh
 
+# Exit on any command failure
+set -e
+
 # Find all packages and run lint-staged in each
 for dir in web/packages/*/; do
     if [ -d "$dir" ]; then
-        cd "$dir"
-        npx lint-staged
-        cd - > /dev/null
+        (cd "$dir" && npx lint-staged)
     fi
 done

--- a/package-lock.json
+++ b/package-lock.json
@@ -24563,7 +24563,7 @@
     },
     "web/packages/hovercards": {
       "name": "@gravatar-com/hovercards",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.22.10",
@@ -24848,7 +24848,7 @@
     },
     "web/packages/quick-editor": {
       "name": "@gravatar-com/quick-editor",
-      "version": "0.0.2",
+      "version": "0.6.0",
       "license": "GPL-2.0-or-later",
       "devDependencies": {
         "@babel/core": "^7.24.5",

--- a/web/packages/hovercards/README.md
+++ b/web/packages/hovercards/README.md
@@ -262,7 +262,7 @@ The `Hovercards` class provides the following methods:
 
 ##### `(static) createHovercard( profileData: ProfileData, options?: { additionalClass?: string; myHash?: string, i18n?: Record< string, string > } ): HTMLDivElement`
 
-This method generates a hovercard element using the provided profile data. It accepts the `profileData` parameter, which represents the data needed to populate the hovercard, and an optional options object that can include properties such as [`additionalClass`](#additionalclass-string) and [`myHash`](#myhash-string). It's useful when you want to display static hovercards on your website.
+This method generates a hovercard element using the provided profile data. It accepts the `profileData` parameter, which represents the data needed to populate the hovercard, and an optional options object that can include properties such as [`additionalClass`](#additionalclass-string), [`myHash`](#myhash-string) and [`i18n`](#i18n-record-string-string-). It's useful when you want to display static hovercards on your website.
 
 ```js
 import { Hovercards } from '@gravatar-com/hovercards';
@@ -285,6 +285,30 @@ const hovercard = Hovercards.createHovercard( {
 } );
 
 document.getElementById( 'container' ).appendChild( hovercard );
+```
+
+##### `(static) createHovercardSkeleton( options?: { additionalClass?: string } ): HTMLDivElement`
+
+This method generates a skeleton hovercard element. It accepts an optional options object that can include the [`additionalClass`](#additionalclass-string) property. It's useful when you want to display a loading state while fetching the Gravatar profile.
+
+```js
+import { Hovercards } from '@gravatar-com/hovercards';
+
+const hovercardSkeleton = Hovercards.createHovercardSkeleton();
+
+document.getElementById( 'container' ).appendChild( hovercardSkeleton );
+```
+
+##### `(static) createHovercardError( avatarUrl: string, message: string, options?: { additionalClass?: string; avatarAlt?: string } ): HTMLDivElement`
+
+This method generates an error hovercard element. It accepts the `avatarUrl` parameter, which represents the URL of the avatar image, the `message` parameter, which represents the error message, and an optional options object that can include properties such as [`additionalClass`](#additionalclass-string) and [`avatarAlt`](#avataralt-string) (default: `'Avatar'`). It's useful when you want to display an error message when fetching the Gravatar profile fails.
+
+```js
+import { Hovercards } from '@gravatar-com/hovercards';
+
+const hovercardError = Hovercards.createHovercardError( 'https://www.gravatar.com/avatar/<HASHED_EMAIL_ADDRESS>', 'Error message' );
+
+document.getElementById( 'container' ).appendChild( hovercardError );
 ```
 
 ##### `attach( target: HTMLElement, options?: { dataAttributeName?: string; ignoreSelector?: string } ): void`

--- a/web/packages/hovercards/lint-staged.config.js
+++ b/web/packages/hovercards/lint-staged.config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	'*.{js,jsx,ts,tsx}': [ () => 'npm run type-check', 'npm run lint:js' ],
 	'*.{css,scss}': 'npm run lint:style',
-	'*.md': 'npm run lint:md:docs',
+	'*.md': 'npm run lint:md',
 	'*.{js,jsx,ts,tsx,json,yaml,yml}': 'npm run format',
 };

--- a/web/packages/hovercards/playground/core.ts
+++ b/web/packages/hovercards/playground/core.ts
@@ -32,4 +32,17 @@ addEventListener( 'DOMContentLoaded', () => {
 			description: '<i>Test</i>, &amp;, &lt;, &gt;, &quot;, &#39;, &#x60;',
 		} )
 	);
+
+	// To test hovercard skeleton
+	document.getElementById( 'hovercard-skeleton' )?.appendChild( Hovercards.createHovercardSkeleton() );
+
+	// To test error hovercard
+	document
+		.getElementById( 'hovercard-error' )
+		?.appendChild(
+			Hovercards.createHovercardError(
+				'https://1.gravatar.com/avatar/767fc9c115a1b989744c755db47feb60?d=retro&r=g',
+				'This is a test message'
+			)
+		);
 } );

--- a/web/packages/hovercards/playground/index.html
+++ b/web/packages/hovercards/playground/index.html
@@ -33,12 +33,14 @@
 					height="60"
 				/>
 				<img
-					src="https://www.gravatar.com/avatar/c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270"
+					src="https://www.gravatar.com/avatar/c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270111"
 					width="60"
 					height="60"
 				/>
 				<div id="attr" data-gravatar-hash="c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270?s=60&d=retro&r=g">@WellyTest</div>
 				<div id="inline-hovercard"></div>
+				<div id="hovercard-skeleton"></div>
+				<div id="hovercard-error"></div>
 			</div>
 			<div id="react-app"></div>
 		</main>

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -19,9 +19,29 @@ export interface ProfileData {
 	verifiedAccounts?: VerifiedAccount[];
 }
 
-export type CreateHovercard = (
-	profileData: ProfileData,
-	options?: { additionalClass?: string; myHash?: string; i18n?: Record< string, string > }
+export interface CreateHovercardOptions {
+	additionalClass?: string;
+	myHash?: string;
+	i18n?: Record< string, string >;
+}
+
+export type CreateHovercard = ( profileData: ProfileData, options?: CreateHovercardOptions ) => HTMLDivElement;
+
+export interface CreateHovercardSkeletonOptions {
+	additionalClass?: string;
+}
+
+export type CreateHovercardSkeleton = ( options?: CreateHovercardSkeletonOptions ) => HTMLDivElement;
+
+export interface CreateHovercardErrorOptions {
+	avatarAlt?: string;
+	additionalClass?: string;
+}
+
+export type CreateHovercardError = (
+	avatarUrl: string,
+	message: string,
+	options?: CreateHovercardErrorOptions
 ) => HTMLDivElement;
 
 export type Attach = ( target: HTMLElement, options?: { dataAttributeName?: string; ignoreSelector?: string } ) => void;
@@ -198,33 +218,6 @@ export default class Hovercards {
 	}
 
 	/**
-	 * Creates a skeleton hovercard element.
-	 *
-	 * @return {HTMLDivElement} The created skeleton hovercard element.
-	 */
-	_createHovercardSkeleton() {
-		const hovercard = dc.createElement( 'div' );
-		hovercard.className = `gravatar-hovercard gravatar-hovercard--skeleton${
-			this._additionalClass ? ` ${ this._additionalClass }` : ''
-		}`;
-
-		hovercard.innerHTML = `
-			<div class="gravatar-hovercard__inner">
-				<div class="gravatar-hovercard__header">
-					<div class="gravatar-hovercard__avatar-link"></div>
-					<div class="gravatar-hovercard__personal-info-link"></div>
-				</div>
-				<div class="gravatar-hovercard__footer">
-					<div class="gravatar-hovercard__social-link"></div>
-					<div class="gravatar-hovercard__profile-link""></div>
-				</div>
-			</div>
-    `;
-
-		return hovercard;
-	}
-
-	/**
 	 * Creates a hovercard element with the provided profile data.
 	 *
 	 * @param {ProfileData} profileData               - The profile data to populate the hovercard.
@@ -306,7 +299,66 @@ export default class Hovercards {
 					</a>
 				</div>
 			</div>
-    `;
+    	`;
+
+		return hovercard;
+	};
+
+	/**
+	 * Creates a skeleton hovercard element.
+	 *
+	 * @param {Object} [options]                 - Optional parameters for the skeleton hovercard.
+	 * @param {string} [options.additionalClass] - Additional CSS class for the skeleton hovercard.
+	 * @return {HTMLDivElement}                  - The created skeleton hovercard element.
+	 */
+	static createHovercardSkeleton: CreateHovercardSkeleton = ( { additionalClass } = {} ) => {
+		const hovercard = dc.createElement( 'div' );
+		hovercard.className = `gravatar-hovercard gravatar-hovercard--skeleton${
+			additionalClass ? ` ${ additionalClass }` : ''
+		}`;
+
+		hovercard.innerHTML = `
+			<div class="gravatar-hovercard__inner">
+				<div class="gravatar-hovercard__header">
+					<div class="gravatar-hovercard__avatar-link"></div>
+					<div class="gravatar-hovercard__personal-info-link"></div>
+				</div>
+				<div class="gravatar-hovercard__footer">
+					<div class="gravatar-hovercard__social-link"></div>
+					<div class="gravatar-hovercard__profile-link""></div>
+				</div>
+			</div>
+    	`;
+
+		return hovercard;
+	};
+
+	/**
+	 * Creates an error hovercard element.
+	 *
+	 * @param {string} avatarUrl                 - The URL of the avatar image.
+	 * @param {string} message                   - The error message to display.
+	 * @param {Object} [options]                 - Optional parameters for the error hovercard.
+	 * @param {string} [options.avatarAlt]       - The alt text for the avatar image.
+	 * @param {string} [options.additionalClass] - Additional CSS class for the error hovercard.
+	 * @return {HTMLDivElement}                  - The created error hovercard element.
+	 */
+	static createHovercardError: CreateHovercardError = (
+		avatarUrl,
+		message,
+		{ avatarAlt = 'Avatar', additionalClass } = {}
+	) => {
+		const hovercard = dc.createElement( 'div' );
+		hovercard.className = `gravatar-hovercard gravatar-hovercard--error${
+			additionalClass ? ` ${ additionalClass }` : ''
+		}`;
+
+		hovercard.innerHTML = `
+			<div class="gravatar-hovercard__inner">
+				<img class="gravatar-hovercard__avatar" src="${ avatarUrl }" width="72" height="72" alt="${ avatarAlt }" />
+				<i class="gravatar-hovercard__error-message">${ message }</i>
+			</div>
+    	`;
 
 		return hovercard;
 	};
@@ -339,7 +391,7 @@ export default class Hovercards {
 					}
 				);
 			} else {
-				hovercard = this._createHovercardSkeleton();
+				hovercard = Hovercards.createHovercardSkeleton( { additionalClass: this._additionalClass } );
 
 				this._onFetchProfileStart( hash );
 
@@ -396,11 +448,15 @@ export default class Hovercards {
 							message = __( this._i18n, 'Internal Server Error.' );
 						}
 
-						hovercard.firstElementChild.classList.add( 'gravatar-hovercard__inner--error' );
-						hovercard.firstElementChild.innerHTML = `
-							<img class="gravatar-hovercard__avatar" src="https://2.gravatar.com/avatar/${ hash }${ params }" width="72" height="72" alt="Avatar" />
-							<i class="gravatar-hovercard__error-message">${ message }</i>
-						`;
+						const hovercardInner = Hovercards.createHovercardError(
+							`https://gravatar.com/avatar/${ hash }${ params }`,
+							message,
+							{ additionalClass: this._additionalClass }
+						).firstElementChild;
+
+						hovercard.classList.add( 'gravatar-hovercard--error' );
+						hovercard.classList.remove( 'gravatar-hovercard--skeleton' );
+						hovercard.replaceChildren( hovercardInner );
 
 						this._onFetchProfileFailure( hash, { code, message } );
 					} );

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -449,7 +449,7 @@ export default class Hovercards {
 						}
 
 						const hovercardInner = Hovercards.createHovercardError(
-							`https://gravatar.com/avatar/${ hash }${ params }`,
+							`https://0.gravatar.com/avatar/${ hash }${ params }`,
 							message,
 							{ additionalClass: this._additionalClass }
 						).firstElementChild;

--- a/web/packages/hovercards/src/index.ts
+++ b/web/packages/hovercards/src/index.ts
@@ -2,7 +2,12 @@ export type { Placement } from './compute-position';
 export type {
 	VerifiedAccount,
 	ProfileData,
+	CreateHovercardOptions,
 	CreateHovercard,
+	CreateHovercardSkeletonOptions,
+	CreateHovercardSkeleton,
+	CreateHovercardErrorOptions,
+	CreateHovercardError,
 	Attach,
 	Detach,
 	OnQueryHovercardRef,

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -173,8 +173,11 @@ $color-blue: #1d4fc4;
 		height: 16px;
 		width: 96px;
 	}
+}
 
-	.gravatar-hovercard__inner--error {
+.gravatar-hovercard--error {
+
+	.gravatar-hovercard__inner {
 		align-items: center;
 		justify-content: start;
 		gap: 34px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If there is no related issue, please create one first.
-->

Related to 108684-gh-Automattic/gravatar

## Proposed Changes

* Export `createHovercardSkeleton` and its relevant types
* Export `createHovercardError` and its relevant types
* Update the relevant docs
* (extra) Export `CreateHovercardOptions` type
* (extra) Adjust husky's `pre-commit` script
* (extra) Fix lint-staged script

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* `cd web/packages/hovercards`
* `npm run build:watch`
* Open another terminal, and `npm run start`
* Check the following section of the playground, all the hovercards should work as expected:

<img width="680" alt="截圖 2024-08-20 下午4 55 39" src="https://github.com/user-attachments/assets/8d98fac5-e289-4d80-8972-9658e16db908">

