### PR TITLE
Fix Hovercards links to the documentation and the repo

### DIFF
--- a/web/packages/hovercards/package.json
+++ b/web/packages/hovercards/package.json
@@ -2,9 +2,9 @@
 	"name": "@gravatar-com/hovercards",
 	"version": "0.9.2",
 	"description": "Add profile hovercards to Gravatar images.",
-	"homepage": "https://github.com/Automattic/gravatar/web/packages/hovercards#readme",
+	"homepage": "https://github.com/Automattic/gravatar/blob/trunk/web/packages/hovercards#readme",
 	"bugs": "https://github.com/Automattic/gravatar/issues",
-	"repository": "https://github.com/Automattic/gravatar/web/packages/hovercards",
+	"repository": "https://github.com/Automattic/gravatar/blob/trunk/web/packages/hovercards",
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",
 	"keywords": [


### PR DESCRIPTION
The current links to "repository" and "homepage" on https://www.npmjs.com/package/@gravatar-com/hovercards are broken (404), I updated them in the `package.json` file.
