### PR TITLE
Hovercards: Adjust the `fields` of the package.json

### DIFF
--- a/web/packages/hovercards/package.json
+++ b/web/packages/hovercards/package.json
@@ -46,7 +46,7 @@
 	},
 	"files": [
 		"dist",
-		"LICENSE.md"
+		"README.md"
 	],
 	"scripts": {
 		"start": "webpack serve --config ./webpack/config.playground.js",


### PR DESCRIPTION
- Remove the `LICENSE.md` from the `fields` (We're using [this shared one](https://github.com/Automattic/gravatar/blob/trunk/docs/LICENSE.md))
- Add `README.md` to the `fields`