### PR TITLE
Fix: URL params & error msg

### DIFF
--- a/web/packages/hovercards/README.md
+++ b/web/packages/hovercards/README.md
@@ -492,6 +492,7 @@ The following phrases are used:
 - `Edit your profile`
 - `View profile`
 - `Sorry, we are unable to load this Gravatar profile.`
+- `Profile not found.`
 - `Too Many Requests.`
 - `Internal Server Error.`
 

--- a/web/packages/hovercards/src/add-query-arg.ts
+++ b/web/packages/hovercards/src/add-query-arg.ts
@@ -1,0 +1,21 @@
+/**
+ * Adds or updates a query parameter to the given URL.
+ *
+ * @param {string} url   - The URL to which the query parameter will be added.
+ * @param {string} key   - The query parameter key to add or update.
+ * @param {string} value - The value of the query parameter to add or update.
+ * @return {string}      - The updated URL with the new or updated query parameter, or an empty string if the URL is invalid.
+ */
+export default function addQueryArg( url: string, key: string, value: string ): string {
+	try {
+		const urlObject = new URL( url );
+		urlObject.searchParams.set( key, value );
+
+		return urlObject.toString();
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( `Failed to add query param: "${ key }" to "${ url }".`, error );
+
+		return '';
+	}
+}

--- a/web/packages/hovercards/src/add-query-arg.ts
+++ b/web/packages/hovercards/src/add-query-arg.ts
@@ -7,15 +7,10 @@
  * @return {string}      - The updated URL with the new or updated query parameter, or an empty string if the URL is invalid.
  */
 export default function addQueryArg( url: string, key: string, value: string ): string {
-	try {
-		const urlObject = new URL( url );
-		urlObject.searchParams.set( key, value );
+	const [ baseUrl, queryStr ] = url.split( '?' );
+	const queryParams = new URLSearchParams( queryStr || '' );
 
-		return urlObject.toString();
-	} catch ( error ) {
-		// eslint-disable-next-line no-console
-		console.error( `Failed to add query param: "${ key }" to "${ url }".`, error );
+	queryParams.set( key, value );
 
-		return '';
-	}
+	return `${ baseUrl }?${ queryParams.toString() }`;
 }

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -1,6 +1,7 @@
 import type { Placement } from './compute-position';
 import computePosition from './compute-position';
 import { escUrl, escHtml } from './sanitizer';
+import addQueryArg from './add-query-arg';
 import __ from './i18n';
 
 interface AccountData {
@@ -255,7 +256,7 @@ export default class Hovercards {
 		const hovercard = dc.createElement( 'div' );
 		hovercard.className = `gravatar-hovercard${ additionalClass ? ` ${ additionalClass }` : '' }`;
 
-		const trackedProfileUrl = escUrl( `${ profileUrl }?utm_source=hovercard` );
+		const trackedProfileUrl = escUrl( addQueryArg( profileUrl, 'utm_source', 'hovercard' ) );
 		const username = escHtml( displayName );
 		const isEditProfile = ! description && myHash === hash;
 		const renderSocialLinks = verifiedAccounts
@@ -411,7 +412,7 @@ export default class Hovercards {
 
 				this._onFetchProfileStart( hash );
 
-				fetch( `${ BASE_API_URL }/${ hash }?source=hovercard` )
+				fetch( addQueryArg( `${ BASE_API_URL }/${ hash }`, 'source', 'hovercard' ) )
 					.then( ( res ) => {
 						// API error handling
 						if ( res.status !== 200 ) {
@@ -457,12 +458,16 @@ export default class Hovercards {
 					.catch( ( code ) => {
 						let message = __( this._i18n, 'Sorry, we are unable to load this Gravatar profile.' );
 
-						if ( code === 429 ) {
-							message = __( this._i18n, 'Too Many Requests.' );
-						}
-
-						if ( code === 500 ) {
-							message = __( this._i18n, 'Internal Server Error.' );
+						switch ( code ) {
+							case 404:
+								message = __( this._i18n, 'Profile not found.' );
+								break;
+							case 429:
+								message = __( this._i18n, 'Too Many Requests.' );
+								break;
+							case 500:
+								message = __( this._i18n, 'Internal Server Error.' );
+								break;
 						}
 
 						const hovercardInner = Hovercards.createHovercardError(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If there is no related issue, please create one first.
-->

- Related to #101
- Related to #93

## Proposed Changes

* Create an `addQueryArg` utility function to fix the issue
* Add a 404 error msg

## Testing Instructions

* Check out this PR
* Follow [the development guidance](https://github.com/Automattic/gravatar/blob/trunk/docs/CONTRIBUTING.md#development-workflow) to run the PR
* Check the requested API URL, and the URL param still works the same:

<img width="749" alt="截圖 2024-10-28 晚上8 27 45" src="https://github.com/user-attachments/assets/cc71e323-6245-485d-a64e-8a02e2858eb1">

* Check the "View Profile" link, and the URL param still works the same:

<img width="276" alt="截圖 2024-10-28 晚上8 28 05" src="https://github.com/user-attachments/assets/c02767fb-eaa0-4dd9-8452-cede78ee83e2">

* For the error msg, code review should be enough