### PR TITLE
Match hovercards style with latest design changes

### DIFF
--- a/web/packages/hovercards/README.md
+++ b/web/packages/hovercards/README.md
@@ -9,7 +9,7 @@
 
 Gravatar Hovercards is an easy-to-use library that brings [Gravatar](https://gravatar.com/) profiles to your website. It converts static [Gravatar images](#1-gravatar-images), or any element with the [`data-gravatar-hash` attribute](#2-elements-with-data-gravatar-hash-attribute) into interactive hovercards.
 
-<img src="https://github.com/user-attachments/assets/7bd0d269-18fa-446a-866f-2273c7f8464d" width="480" height="356" />
+<img src="https://github.com/user-attachments/assets/b12f944e-1134-4e5e-a2ec-cbd27af59bc7" width="480" height="356" />
 
 ## Table of Contents
 

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -365,11 +365,13 @@ export default class Hovercards {
 						${ location ? `<p class="gravatar-hovercard__location">${ escHtml( location ) }</p>` : '' }
 					</a>
 				</div>
-				<div class="gravatar-hovercard__body">
-					${ description ? `<p class="gravatar-hovercard__description">${ escHtml( description ) }</p>` : '' }
-				</div>
+				${
+					description &&
+					`<div class="gravatar-hovercard__body">
+						<p class="gravatar-hovercard__description">${ escHtml( description ) }</p>
+					</div>`
+				}
 				<div class="gravatar-hovercard__social-links">
-					<img class="gravatar-hovercard__verified-icon" src="https://secure.gravatar.com/icons/verified.svg" width="32" height="32" title="Verified accounts" alt="Verified icon">
 					<a class="gravatar-hovercard__social-link" href="${ trackedProfileUrl }" target="_blank" data-service-name="gravatar">
 						<img class="gravatar-hovercard__social-icon" src="https://secure.gravatar.com/icons/gravatar.svg" width="32" height="32" alt="Gravatar" />
 					</a>
@@ -610,7 +612,6 @@ export default class Hovercards {
 					<div class="gravatar-hovercard__avatar-link"></div>
 					<div class="gravatar-hovercard__personal-info-link"></div>
 				</div>
-				<div class="gravatar-hovercard__body"></div>
 				<div class="gravatar-hovercard__social-links">
 					<div class="gravatar-hovercard__social-link"></div>
 					<div class="gravatar-hovercard__social-link"></div>

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -40,7 +40,7 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		flex-direction: column;
 		justify-content: space-between;
 		width: 336px;
-		min-height: 323px;
+		min-height: 273px;
 		position: relative;
 		padding: 24px 24px 16px;
 		background-color: $color-white;
@@ -108,11 +108,6 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 	.gravatar-hovercard__description {
 
 		@include ellipsis(2);
-	}
-
-	.gravatar-hovercard__verified-icon {
-		padding: 4px;
-		box-sizing: border-box;
 	}
 
 	.gravatar-hovercard__social-links {


### PR DESCRIPTION
This PR adjusts the hovercards to match the latest design changes.
Here are some examples shared by our designer, Andrei (@Luchadores):

![image](https://github.com/user-attachments/assets/651f6e42-81d2-440b-9537-489180e4a6bd)

Andrei also asked us to remove the verified icon from all variations of the hovercards.

![hovercard](https://github.com/user-attachments/assets/b12f944e-1134-4e5e-a2ec-cbd27af59bc7)


## Testing Instructions

* Check out this PR and test it through the playground
* Check if the designs match what was shared by Andrei
