### PR TITLE
Update Header Image proportions

### DIFF
--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -55,7 +55,7 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		position: absolute;
 		top: 0;
 		left: 50%;
-		height: 96px;
+		height: 75px;
 		width: 100%;
 		transform: translateX(-50%);
 	}


### PR DESCRIPTION
## Proposed Changes

This PR changes the header image height to keep the same aspect ratio used on the profile page.
This change prevents the header image on the hovercards from having a blank space when using an image with the recommended size. 

Discussion [here](https://a8c.slack.com/archives/C06B7CLBL2D/p1732803911921529).

Before
![image](https://github.com/user-attachments/assets/2249e890-8873-46eb-b5d8-81c4791953d3)

After
![image](https://github.com/user-attachments/assets/8512252a-cd48-4307-b203-05ef1d6f4920)

## Testing Instructions

* Run the playground and check if the blank space on Ronnie's hovercard is gone
