### PR TITLE
Fix Profile URL truncation on Firefox

### DIFF
--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -366,10 +366,11 @@ export default class Hovercards {
 					</a>
 				</div>
 				${
-					description &&
-					`<div class="gravatar-hovercard__body">
-						<p class="gravatar-hovercard__description">${ escHtml( description ) }</p>
-					</div>`
+					description
+						? `<div class="gravatar-hovercard__body">
+								<p class="gravatar-hovercard__description">${ escHtml( description ) }</p>
+							</div>`
+						: ''
 				}
 				<div class="gravatar-hovercard__social-links">
 					<a class="gravatar-hovercard__social-link" href="${ trackedProfileUrl }" target="_blank" data-service-name="gravatar">

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -151,9 +151,11 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 	}
 
 	.gravatar-hovercard__profile-url {
-
-		@include ellipsis(1);
-
+		// webkit-box used by ellipsis mixin
+		// doesn't work well for URLs on Firefox
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 		color: $color-gray;
 	}
 

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -151,11 +151,11 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 	}
 
 	.gravatar-hovercard__profile-url {
-		// webkit-box used by ellipsis mixin
-		// doesn't work well for URLs on Firefox
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
+
+		@include ellipsis(1);
+
+		/* Ensure consistent word-breaking across browsers. */
+		word-break: break-all;
 		color: $color-gray;
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue with the Hovercards profile URL truncation on Firefox.

| Current | Expected |
|-|-|
| ![image](https://github.com/user-attachments/assets/9dfb0bc3-e14d-4031-b94e-89275d0c6dd5) | ![image](https://github.com/user-attachments/assets/7c9c70ab-8854-44e3-8d42-b38668f635b0) |

It also fixes an issue where profiles with no description show a `null` inside the hovercard body.

![image](https://github.com/user-attachments/assets/23fa67c8-71dd-4f57-8ec8-f27b0fda7bce)

## Testing Instructions

* Checkout this branch and run the playground on Firefox
* Add a bigger `profileUrl` to the [inline-hovercard](https://github.com/Automattic/gravatar/blob/trunk/web/packages/hovercards/playground/core.ts#L26) data
* Check if the URL is truncated as expected
* The second issue is a bit trickier to test
* I only spotted it while visiting https://gravatar.com/profile/design/card for a profile without a `description`
