### PR TITLE
Hovercard: Make the profile URL a link

### DIFF
--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -380,7 +380,9 @@ export default class Hovercards {
 				</div>
 				${ ctaButtons }
 				<div class="gravatar-hovercard__footer">
-					<span class="gravatar-hovercard__profile-url" title="${ profileUrl }">${ profileUrl.replace( 'https://', '' ) }</span>
+					<a class="gravatar-hovercard__profile-url" title="${ profileUrl }" href="${ trackedProfileUrl }" target="_blank">
+						${ profileUrl.replace( 'https://', '' ) }
+					</a>
 					<a
 						class="gravatar-hovercard__profile-link${ isEditProfile ? ' gravatar-hovercard__profile-link--edit' : '' }"
 						href="${ isEditProfile ? 'https://gravatar.com/profiles/edit?utm_source=hovercard' : trackedProfileUrl }"

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -157,6 +157,8 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		/* Ensure consistent word-breaking across browsers. */
 		word-break: break-all;
 		color: $color-gray;
+
+		text-decoration: none;
 	}
 
 	.gravatar-hovercard__profile-link {


### PR DESCRIPTION
Context: p1738251231232569-slack-C06B7CLBL2D

## Proposed Changes

* Makes the URL a link. 

![Screenshot 2025-01-30 at 7 14 34 pm](https://github.com/user-attachments/assets/a294dd0a-7858-4626-a3be-b7d68903ea9a)

## Testing Instructions
* Rebuild.
* Go into the hovercard playground.
* Make sure the URL is clickable and looks the same as before.