### PR TITLE
Show Calendly in Contacts if available

### DIFF
--- a/web/packages/hovercards/playground/core.ts
+++ b/web/packages/hovercards/playground/core.ts
@@ -49,6 +49,13 @@ addEventListener( 'DOMContentLoaded', () => {
 					isHidden: false,
 				},
 				{
+					type: 'calendly',
+					label: 'Calendly',
+					icon: 'https://gravatar.com/icons/calendly.svg',
+					url: 'https://calendly.com/joao-heringer',
+					isHidden: true,
+				},
+				{
 					type: 'wordpress',
 					label: 'WordPress',
 					icon: 'https://gravatar.com/icons/wordpress.svg',

--- a/web/packages/hovercards/playground/core.ts
+++ b/web/packages/hovercards/playground/core.ts
@@ -64,12 +64,12 @@ addEventListener( 'DOMContentLoaded', () => {
 				},
 			],
 			contactInfo: {
-				// home_phone: '',
-				// work_phone: '',
-				// cell_phone: '12312312312',
-				// email: 'email@email.com',
-				// contact_form: '',
-				//calendar: 'https://calendar.com',
+				home_phone: '',
+				work_phone: '',
+				cell_phone: '12312312312',
+				email: 'email@email.com',
+				contact_form: '',
+				calendar: 'https://calendar.com',
 			},
 			payments: {
 				links: [],

--- a/web/packages/hovercards/playground/core.ts
+++ b/web/packages/hovercards/playground/core.ts
@@ -53,7 +53,7 @@ addEventListener( 'DOMContentLoaded', () => {
 					label: 'Calendly',
 					icon: 'https://gravatar.com/icons/calendly.svg',
 					url: 'https://calendly.com/joao-heringer',
-					isHidden: true,
+					isHidden: false,
 				},
 				{
 					type: 'wordpress',
@@ -64,12 +64,12 @@ addEventListener( 'DOMContentLoaded', () => {
 				},
 			],
 			contactInfo: {
-				home_phone: '',
-				work_phone: '',
-				cell_phone: '12312312312',
-				email: 'email@email.com',
-				contact_form: '',
-				calendar: 'https://calendar.com',
+				// home_phone: '',
+				// work_phone: '',
+				// cell_phone: '12312312312',
+				// email: 'email@email.com',
+				// contact_form: '',
+				//calendar: 'https://calendar.com',
 			},
 			payments: {
 				links: [],

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -27,6 +27,7 @@ export type ContactInfo = Partial< {
 	email: string;
 	contact_form: string;
 	calendar: string;
+	calendly: string;
 } >;
 
 export interface PaymentLink {
@@ -292,6 +293,11 @@ export default class Hovercards {
 		const hovercard = dc.createElement( 'div' );
 		hovercard.className = `gravatar-hovercard${ additionalClass ? ` ${ additionalClass }` : '' }`;
 
+		const calendly = verifiedAccounts.find( ( l ) => l.type === 'calendly' && ! l.isHidden );
+		if ( contactInfo && calendly ) {
+			contactInfo.calendly = calendly.url;
+		}
+
 		const trackedProfileUrl = escUrl( addQueryArg( profileUrl, 'utm_source', 'hovercard' ) );
 		const username = escHtml( displayName );
 		const isEditProfile = ! description && myHash === hash;
@@ -510,6 +516,7 @@ export default class Hovercards {
 			cell_phone: 'icons/mobile-phone.svg',
 			contact_form: 'icons/envelope.svg',
 			calendar: 'icons/calendar.svg',
+			calendly: 'icons/calendly.svg',
 		};
 
 		const getUrl = ( type: string, value: string ) => {
@@ -518,6 +525,7 @@ export default class Hovercards {
 					return `mailto:${ value }`;
 				case 'contact_form':
 				case 'calendar':
+				case 'calendly':
 					return value.startsWith( 'http' ) ? value : `https://${ value }`;
 				default:
 					return null;

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -293,7 +293,7 @@ export default class Hovercards {
 		const hovercard = dc.createElement( 'div' );
 		hovercard.className = `gravatar-hovercard${ additionalClass ? ` ${ additionalClass }` : '' }`;
 
-		const calendly = verifiedAccounts.find( ( l ) => l.type === 'calendly' && ! l.isHidden );
+		const calendly = verifiedAccounts.find( ( account ) => account.type === 'calendly' && ! account.isHidden );
 		if ( contactInfo && calendly ) {
 			contactInfo.calendly = calendly.url;
 		}


### PR DESCRIPTION
## Proposed Changes

For parity with the public profiles, this PR adjusts the hovercards to show Calendly in the Contact drawer when available.

![image](https://github.com/user-attachments/assets/12b3ad5d-52f9-4472-96da-874e55604813)

## Testing Instructions

* Checkout this branch
* Build and run the playground
* Play with the playground data to check if Calendly is shown when applicable

