### PR TITLE
Adds support for the initials avatar type

### DIFF
--- a/web/packages/hovercards/playground/index.html
+++ b/web/packages/hovercards/playground/index.html
@@ -38,19 +38,29 @@
 		<main id="main">
 			<div id="vanilla">
 				<img
-					src="https://www.gravatar.com/avatar/c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270?s=128&d=retro&r=g"
+					src="https://gravatar.com/avatar/c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270?s=128&d=retro&r=g"
 					width="60"
 					height="60"
 				/>
 				<img
-						src="https://www.gravatar.com/avatar/a8fb08baaca16a8c0c87177d3d54499b"
-						width="60"
-						height="60"
+					src="https://gravatar.com/avatar/a8fb08baaca16a8c0c87177d3d54499b"
+					width="60"
+					height="60"
 				/>
 				<img
-						src="https://www.gravatar.com/avatar/c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270111"
-						width="60"
-						height="60"
+					src="https://gravatar.com/avatar/c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270111"
+					width="60"
+					height="60"
+				/>
+				<img
+					src="https://gravatar.com/avatar/c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270?f=y&d=initials&initials=A8"
+					width="60"
+					height="60"
+				/>
+				<img
+					src="https://gravatar.com/avatar/a3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270?f=y&d=initials&initials=A8"
+					width="60"
+					height="60"
 				/>
 				<div id="attr" data-gravatar-hash="c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270?s=60&d=retro&r=g">@WellyTest</div>
 			</div>

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -253,7 +253,22 @@ export default class Hovercards {
 				const d = p.get( 'd' ) || p.get( 'default' );
 				const f = p.get( 'f' ) || p.get( 'forcedefault' );
 				const r = p.get( 'r' ) || p.get( 'rating' );
-				params = [ d && `d=${ d }`, f && `f=${ f }`, r && `r=${ r }` ].filter( Boolean ).join( '&' );
+				const initials = p.get( 'initials' );
+				const name = p.get( 'name' );
+				const txtColor = p.get( 'txt_color' );
+				const bgColor = p.get( 'bg_color' );
+
+				params = [
+					d && `d=${ d }`,
+					f && `f=${ f }`,
+					r && `r=${ r }`,
+					initials && `initials=${ initials }`,
+					name && `name=${ name }`,
+					txtColor && `txt_color=${ txtColor }`,
+					bgColor && `bg_color=${ bgColor }`,
+				]
+					.filter( Boolean )
+					.join( '&' );
 
 				return {
 					id: `gravatar-hovercard-${ hash }-${ idx }`,
@@ -549,11 +564,11 @@ export default class Hovercards {
 
 			return `
 				<li class="gravatar-hovercard__drawer-item">
-					<img 
-						class="gravatar-hovercard__drawer-item-icon" 
-						width="24" 
-						height="24" 
-						src="https://secure.gravatar.com/${ icons[ key ] }" 
+					<img
+						class="gravatar-hovercard__drawer-item-icon"
+						width="24"
+						height="24"
+						src="https://secure.gravatar.com/${ icons[ key ] }"
 						alt=""
 					>
 					<div class="gravatar-hovercard__drawer-item-info">

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -234,11 +234,15 @@ export default class Hovercards {
 				const dataAttrValue = ref.dataset[ camelAttrName ];
 
 				if ( dataAttrValue ) {
-					hash = dataAttrValue.split( '?' )[ 0 ];
-					params = dataAttrValue;
+					const part = dataAttrValue.split( '?' );
+
+					hash = part[ 0 ];
+					params = part.length > 1 ? part[ 1 ] : '';
 				} else if ( ref.tagName === 'IMG' ) {
-					hash = ( ref as HTMLImageElement ).src.split( '/' ).pop().split( '?' )[ 0 ];
-					params = ( ref as HTMLImageElement ).src;
+					const part = ( ref as HTMLImageElement ).src.split( '/' ).pop().split( '?' );
+
+					hash = part[ 0 ];
+					params = part.length > 1 ? part[ 1 ] : '';
 				}
 
 				if ( ! hash ) {


### PR DESCRIPTION
The initials avatar has some additional query params, and these need to be copied through to the hovercard.

It also fixes a bug where the whole URL was being passed to `URLSearchParams`, when instead it should just be the query fragment. Passing the whole URL meant that the first parameter was being lost

## Testing Instructions

- `npm run build`
- `npm run start`
- Hover over the pink A8 and blue A8 avatar and confirm the hovercard shows the same avatar in the hovercard
- Everything else should work as expected