### PR TITLE
Add onCanShowHovercard param

### DIFF
--- a/web/packages/hovercards/README.md
+++ b/web/packages/hovercards/README.md
@@ -264,6 +264,10 @@ This callback function is triggered when the hovercard is shown. It takes the Gr
 
 This callback function is triggered when the hovercard is hidden. It takes the Gravatar hash and the hovercard element as parameters.
 
+##### `onCanShowHovercard: ( hash: string ) => bool`
+
+This callback function is triggered just before a hovercard is shown, giving you control over the card at runtime. It takes the Gravatar hash and returns a boolean value. If the value returned is `false` then the card won't be shown.
+
 #### Methods
 
 The `Hovercards` class provides the following methods:
@@ -435,7 +439,7 @@ function App() {
 
     useEffect( () => {
         if ( containerRef.current ) {
-            attach( containerRef.current );   
+            attach( containerRef.current );
         }
     }, [ attach ] );
 
@@ -470,7 +474,7 @@ function Avatar( { email } ) {
 
     useEffect( () => {
         if ( imgRef.current ) {
-            attach( imgRef.current ); 
+            attach( imgRef.current );
         }
     }, [ attach ] );
 

--- a/web/packages/hovercards/playground/core.ts
+++ b/web/packages/hovercards/playground/core.ts
@@ -9,6 +9,13 @@ addEventListener( 'DOMContentLoaded', () => {
 		placement: 'top',
 		// To test the empty about me case
 		myHash: '99c3338797c95c418d9996bd39931506',
+		onCanShowHovercard: ( hash ) => {
+			if ( hash === 'a2bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270' ) {
+				return false;
+			}
+
+			return true;
+		},
 	};
 	const hovercards = new Hovercards( options );
 

--- a/web/packages/hovercards/playground/index.html
+++ b/web/packages/hovercards/playground/index.html
@@ -62,6 +62,11 @@
 					width="60"
 					height="60"
 				/>
+				<img
+					src="https://gravatar.com/avatar/a2bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270?f=y&d=initials&initials=A9"
+					width="60"
+					height="60"
+				/>
 				<div id="attr" data-gravatar-hash="c3bb8d897bb538896708195dd9eb162f585654611c50a3a1c9a16a7b64f33270?s=60&d=retro&r=g">@WellyTest</div>
 			</div>
 			<div id="react-app"></div>

--- a/web/packages/hovercards/playground/react.tsx
+++ b/web/packages/hovercards/playground/react.tsx
@@ -17,10 +17,11 @@ const props: HovercardsProps = {
 };
 
 function App() {
-	// eslint-disable-next-line no-console
 	const { attach } = useHovercards( {
+		// eslint-disable-next-line no-console
 		onFetchProfileSuccess: ( hash ) => console.log( hash ),
 		onCanShowHovercard: ( hash ) => {
+			// eslint-disable-next-line no-console
 			console.log( 'Can show hovercard: ', hash );
 			return true;
 		},

--- a/web/packages/hovercards/playground/react.tsx
+++ b/web/packages/hovercards/playground/react.tsx
@@ -18,7 +18,13 @@ const props: HovercardsProps = {
 
 function App() {
 	// eslint-disable-next-line no-console
-	const { attach } = useHovercards( { onFetchProfileSuccess: ( hash ) => console.log( hash ) } );
+	const { attach } = useHovercards( {
+		onFetchProfileSuccess: ( hash ) => console.log( hash ),
+		onCanShowHovercard: ( hash ) => {
+			console.log( 'Can show hovercard: ', hash );
+			return true;
+		},
+	} );
 	const containerRef = useRef( null );
 
 	useEffect( () => {

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -120,6 +120,7 @@ export type Options = Partial< {
 	onFetchProfileFailure: OnFetchProfileFailure;
 	onHovercardShown: OnHovercardShown;
 	onHovercardHidden: OnHovercardHidden;
+	onCanShowHovercard: ( hash: string ) => boolean;
 } >;
 
 interface HovercardRef {
@@ -149,6 +150,7 @@ export default class Hovercards {
 	_onFetchProfileFailure: OnFetchProfileFailure;
 	_onHovercardShown: OnHovercardShown;
 	_onHovercardHidden: OnHovercardHidden;
+	_canShowHovercard: ( hash: string ) => boolean;
 	_i18n: Record< string, string > = {};
 
 	// Variables
@@ -172,6 +174,7 @@ export default class Hovercards {
 		onFetchProfileFailure = () => {},
 		onHovercardShown = () => {},
 		onHovercardHidden = () => {},
+		onCanShowHovercard = () => true,
 		i18n = {},
 	}: Options = {} ) {
 		this._placement = placement;
@@ -188,6 +191,7 @@ export default class Hovercards {
 		this._onFetchProfileFailure = onFetchProfileFailure;
 		this._onHovercardShown = onHovercardShown;
 		this._onHovercardHidden = onHovercardHidden;
+		this._canShowHovercard = onCanShowHovercard;
 		this._i18n = i18n;
 	}
 
@@ -697,6 +701,11 @@ export default class Hovercards {
 	_showHovercard( { id, hash, params, ref }: HovercardRef ) {
 		const timeoutId = setTimeout( () => {
 			if ( dc.getElementById( id ) ) {
+				return;
+			}
+
+			// Let client decide if we can show the hovercard
+			if ( ! this._canShowHovercard( hash ) ) {
 				return;
 			}
 

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -104,6 +104,8 @@ export type OnHovercardShown = ( hash: string, hovercard: HTMLDivElement ) => vo
 
 export type OnHovercardHidden = ( hash: string, hovercard: HTMLDivElement ) => void;
 
+export type OnCanShowHovercard = ( hash: string ) => boolean;
+
 export type Options = Partial< {
 	placement: Placement;
 	offset: number;
@@ -120,7 +122,7 @@ export type Options = Partial< {
 	onFetchProfileFailure: OnFetchProfileFailure;
 	onHovercardShown: OnHovercardShown;
 	onHovercardHidden: OnHovercardHidden;
-	onCanShowHovercard: ( hash: string ) => boolean;
+	onCanShowHovercard: OnCanShowHovercard;
 } >;
 
 interface HovercardRef {
@@ -150,7 +152,7 @@ export default class Hovercards {
 	_onFetchProfileFailure: OnFetchProfileFailure;
 	_onHovercardShown: OnHovercardShown;
 	_onHovercardHidden: OnHovercardHidden;
-	_canShowHovercard: ( hash: string ) => boolean;
+	_canShowHovercard: OnCanShowHovercard;
 	_i18n: Record< string, string > = {};
 
 	// Variables

--- a/web/packages/hovercards/src/use-hovercards.ts
+++ b/web/packages/hovercards/src/use-hovercards.ts
@@ -26,6 +26,7 @@ export default function useHovercards( {
 	onFetchProfileFailure,
 	onHovercardShown,
 	onHovercardHidden,
+	onCanShowHovercard,
 }: Options = {} ): UseHovercardsReturnValues {
 	// These callbacks / variables won't trigger hooks update and will always be the latest
 	const onQueryHovercardRefRef = useLatest( onQueryHovercardRef );
@@ -34,6 +35,7 @@ export default function useHovercards( {
 	const onFetchProfileFailureRef = useLatest( onFetchProfileFailure );
 	const onHovercardShownRef = useLatest( onHovercardShown );
 	const onHovercardHiddenRef = useLatest( onHovercardHidden );
+	const onCanShowHovercardRef = useLatest( onCanShowHovercard );
 	const i18nRef = useLatest( i18n );
 	// Instantiate the Hovercards class only when the options change
 	const { attach, detach } = useMemo(
@@ -54,6 +56,7 @@ export default function useHovercards( {
 				onFetchProfileFailure: onFetchProfileFailureRef.current,
 				onHovercardShown: onHovercardShownRef.current,
 				onHovercardHidden: onHovercardHiddenRef.current,
+				onCanShowHovercard: onCanShowHovercardRef.current,
 			} ),
 		[
 			placement,
@@ -71,6 +74,7 @@ export default function useHovercards( {
 			onFetchProfileFailureRef,
 			onHovercardShownRef,
 			onHovercardHiddenRef,
+			onCanShowHovercardRef,
 		]
 	);
 


### PR DESCRIPTION
Adds a `onCanShowHovercard` parameter to the hovercard library. This allows the library user to have final decision about whether a hovercard is shown.

The use case is when the user wants the avatar to have a click action, but a hovercard on hover. If the avatar is clicked we want to prevent the hovercard from then showing.

## Testing Instructions

- `npm run build`
- `npm run start`
- Hover over the `A9` and confirm a hovercard is not shown. The others should show as expected