### PR TITLE
Export missed methods and types for the React hook and component

### DIFF
--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -651,7 +651,7 @@ export default class Hovercards {
 					<div class="gravatar-hovercard__profile-link"></div>
 				</div>
 			</div>
-    	`;
+		`;
 
 		return hovercard;
 	};
@@ -681,7 +681,7 @@ export default class Hovercards {
 				<img class="gravatar-hovercard__avatar" src="${ avatarUrl }" width="104" height="104" alt="${ avatarAlt }" />
 				<i class="gravatar-hovercard__error-message">${ message }</i>
 			</div>
-    	`;
+		`;
 
 		return hovercard;
 	};

--- a/web/packages/hovercards/src/index.react.ts
+++ b/web/packages/hovercards/src/index.react.ts
@@ -1,8 +1,17 @@
 export type { Placement } from './assign-position';
 export type {
 	VerifiedAccount,
+	ContactInfo,
+	Payments,
+	PaymentLink,
+	CryptoWallet,
 	ProfileData,
+	CreateHovercardOptions,
 	CreateHovercard,
+	CreateHovercardSkeletonOptions,
+	CreateHovercardSkeleton,
+	CreateHovercardErrorOptions,
+	CreateHovercardError,
 	Attach,
 	Detach,
 	OnQueryHovercardRef,

--- a/web/packages/hovercards/src/index.react.ts
+++ b/web/packages/hovercards/src/index.react.ts
@@ -1,28 +1,5 @@
 export type { Placement } from './assign-position';
-export type {
-	VerifiedAccount,
-	ContactInfo,
-	Payments,
-	PaymentLink,
-	CryptoWallet,
-	ProfileData,
-	CreateHovercardOptions,
-	CreateHovercard,
-	CreateHovercardSkeletonOptions,
-	CreateHovercardSkeleton,
-	CreateHovercardErrorOptions,
-	CreateHovercardError,
-	Attach,
-	Detach,
-	OnQueryHovercardRef,
-	OnFetchProfileStart,
-	OnFetchProfileSuccess,
-	FetchProfileError,
-	OnFetchProfileFailure,
-	OnHovercardShown,
-	OnHovercardHidden,
-	Options,
-} from './core';
+export type * from './core';
 export type { HovercardsProps } from './hovercards';
 export type { UseHovercardsReturnValues } from './use-hovercards';
 

--- a/web/packages/hovercards/src/index.ts
+++ b/web/packages/hovercards/src/index.ts
@@ -1,27 +1,4 @@
 export type { Placement } from './assign-position';
-export type {
-	VerifiedAccount,
-	ContactInfo,
-	Payments,
-	PaymentLink,
-	CryptoWallet,
-	ProfileData,
-	CreateHovercardOptions,
-	CreateHovercard,
-	CreateHovercardSkeletonOptions,
-	CreateHovercardSkeleton,
-	CreateHovercardErrorOptions,
-	CreateHovercardError,
-	Attach,
-	Detach,
-	OnQueryHovercardRef,
-	OnFetchProfileStart,
-	OnFetchProfileSuccess,
-	FetchProfileError,
-	OnFetchProfileFailure,
-	OnHovercardShown,
-	OnHovercardHidden,
-	Options,
-} from './core';
+export type * from './core';
 
 export { default as Hovercards } from './core';

--- a/web/packages/hovercards/src/use-hovercards.ts
+++ b/web/packages/hovercards/src/use-hovercards.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
-import type { Options, Attach, Detach, CreateHovercard } from './core';
+import type { Options, Attach, Detach, CreateHovercard, CreateHovercardSkeleton, CreateHovercardError } from './core';
 import Hovercards from './core';
 import useLatest from './use-latest';
 
@@ -8,6 +8,8 @@ export interface UseHovercardsReturnValues {
 	attach: Attach;
 	detach: Detach;
 	createHovercard: CreateHovercard;
+	createHovercardSkeleton: CreateHovercardSkeleton;
+	createHovercardError: CreateHovercardError;
 }
 
 export default function useHovercards( {
@@ -78,5 +80,11 @@ export default function useHovercards( {
 		return detach;
 	}, [ detach ] );
 
-	return { attach, detach, createHovercard: Hovercards.createHovercard };
+	return {
+		attach,
+		detach,
+		createHovercard: Hovercards.createHovercard,
+		createHovercardSkeleton: Hovercards.createHovercardSkeleton,
+		createHovercardError: Hovercards.createHovercardError,
+	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If there is no related issue, please create one first.
-->

To export more methods and types for the React hook and component

## Proposed Changes

* Export missed methods for the React hook 
* Export missed types for the React hook and component (by using `export type * from 'somewhere`)
* (Extra) Format code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* For the types:
  * `cd web/packages/hovercards && npm run build`
  * In [this file](https://github.com/Automattic/gravatar/blob/trunk/web/packages/hovercards/playground/core.ts), the types should still work
* For the methods: Code review should be fine
