### PR TITLE
Add functions to determine open/close status

### DIFF
--- a/web/packages/quick-editor/README.md
+++ b/web/packages/quick-editor/README.md
@@ -165,11 +165,15 @@ type QuickEditorCoreOptions = Partial< {
 - **`onOpened: () => void`**:
   A callback function that gets called when the editor popup is opened. This can be used for logging, analytics, or other actions when the popup is triggered.
 
+- **`onClosed: () => void`**:
+  A callback function that gets called when the editor popup is closed.
+
 #### Public functions
 
-- **`open: ( email?: string ) => void`**: A function for triggering the Gravatar Quick Editor popup.
-  It can receive an email address to identify the profile to be edited.
-
+- **`open: ( email?: string ) => boolean`**: A function for triggering the Gravatar Quick Editor popup.
+  It can receive an email address to identify the profile to be edited. `true` is returned if successfully opened, `false` otherwise.
+- **`close: () => void`**: Closes an open Gravatar Quick Editor popup.
+- **`isOpen: () => boolean`**: Return `true` if the popup is open, `false` otherwise.
 
 ### Valid Scope Values
 
@@ -191,4 +195,3 @@ We welcome contributions to this project. Please follow the guidelines outlined 
 ## License
 
 Gravatar Hovercards is licensed under [GNU General Public License v2 (or later)](../../../docs/LICENSE.md).
-

--- a/web/packages/quick-editor/playground/index.html
+++ b/web/packages/quick-editor/playground/index.html
@@ -32,20 +32,21 @@
 	<div class="gravatar-quick-editor">
 		<h1>Gravatar Quick Editor</h1>
 		<img
-				class="avatar"
-				alt="Avatar"
-				src="https://1.gravatar.com/avatar/4f615f4811330c1883eb440d6621e7c2bb8e4bbb610f74e1159d2973a0aea99f?size=256"
+			class="avatar"
+			alt="Avatar"
+			src="https://1.gravatar.com/avatar/4f615f4811330c1883eb440d6621e7c2bb8e4bbb610f74e1159d2973a0aea99f?size=256"
 		/>
 		<button id="edit-avatar">Edit Avatar</button>
 	</div>
 	<div class="gravatar-quick-editor">
 		<h1>Gravatar Quick Editor Core</h1>
 		<img
-				class="avatar-core"
-				alt="Avatar Core"
-				src="https://1.gravatar.com/avatar/4f615f4811330c1883eb440d6621e7c2bb8e4bbb610f74e1159d2973a0aea99f?size=256"
+			class="avatar-core"
+			alt="Avatar Core"
+			src="https://1.gravatar.com/avatar/4f615f4811330c1883eb440d6621e7c2bb8e4bbb610f74e1159d2973a0aea99f?size=256"
 		/>
 		<button id="edit-avatar-core">Edit Avatar</button>
+		<button id="edit-avatar-core-close" disabled>Close popup</button>
 	</div>
 </div>
 </body>

--- a/web/packages/quick-editor/playground/index.ts
+++ b/web/packages/quick-editor/playground/index.ts
@@ -5,6 +5,12 @@ import { GravatarQuickEditor, GravatarQuickEditorCore } from '../dist';
 import type { ProfileUpdatedType } from '../dist';
 
 document.addEventListener( 'DOMContentLoaded', () => {
+	const closeButton = document.querySelector( '#edit-avatar-core-close' ) as HTMLButtonElement | null;
+
+	if ( ! closeButton ) {
+		return;
+	}
+
 	new GravatarQuickEditor( {
 		email: 'joao.heringer@automattic.com',
 		scope: [ 'avatars' ],
@@ -20,6 +26,25 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			// eslint-disable-next-line
 			console.log( type );
 		},
+		onOpened: () => {
+			// eslint-disable-next-line
+			console.log( 'opened' );
+
+			// eslint-disable-next-line
+			console.log( 'isOpen = ' + quickEditorCore.isOpen() );
+
+			closeButton.disabled = false;
+		},
+		onClosed: () => {
+			// eslint-disable-next-line
+			console.log( 'closed' );
+
+			closeButton.disabled = true;
+		},
+	} );
+
+	closeButton.addEventListener( 'click', () => {
+		quickEditorCore.close();
 	} );
 
 	document.querySelector( '#edit-avatar-core' )?.addEventListener( 'click', () => {

--- a/web/packages/quick-editor/src/index.ts
+++ b/web/packages/quick-editor/src/index.ts
@@ -2,8 +2,11 @@ export type {
 	Scope,
 	ProfileUpdatedType,
 	Open,
+	Close,
+	IsOpen,
 	OnProfileUpdated,
 	OnOpened,
+	OnClosed,
 	QuickEditorCoreOptions,
 } from './quick-editor-core';
 

--- a/web/packages/quick-editor/src/index.ts
+++ b/web/packages/quick-editor/src/index.ts
@@ -1,15 +1,4 @@
-export type {
-	Scope,
-	ProfileUpdatedType,
-	Open,
-	Close,
-	IsOpen,
-	OnProfileUpdated,
-	OnOpened,
-	OnClosed,
-	QuickEditorCoreOptions,
-} from './quick-editor-core';
-
+export type * from './quick-editor-core';
 export type { QuickEditorOptions } from './quick-editor';
 
 export { default as GravatarQuickEditor } from './quick-editor';

--- a/web/packages/quick-editor/src/quick-editor-core.ts
+++ b/web/packages/quick-editor/src/quick-editor-core.ts
@@ -18,6 +18,8 @@ export type Scope = ( typeof ScopeList )[ number ][];
 export type ProfileUpdatedType = 'avatar_updated' | 'profile_updated';
 
 export type Open = ( email?: string ) => boolean;
+export type Close = () => void;
+export type IsOpen = () => boolean;
 
 export type OnProfileUpdated = ( type: ProfileUpdatedType ) => void;
 
@@ -107,13 +109,13 @@ export class GravatarQuickEditorCore {
 		return true;
 	};
 
-	close = () => {
+	close: Close = () => {
 		if ( this._window ) {
 			this._window.close();
 		}
 	};
 
-	isOpen: () => boolean = () => {
+	isOpen: IsOpen = () => {
 		return this._window !== null && ! this._window.closed;
 	};
 

--- a/web/packages/quick-editor/src/quick-editor-core.ts
+++ b/web/packages/quick-editor/src/quick-editor-core.ts
@@ -11,15 +11,18 @@ const ScopeList = [
 	'privacy',
 ] as const;
 
+const WINDOW_CHECK_INTERVAL = 500;
+
 export type Scope = ( typeof ScopeList )[ number ][];
 
 export type ProfileUpdatedType = 'avatar_updated' | 'profile_updated';
 
-export type Open = ( email?: string ) => void;
+export type Open = ( email?: string ) => boolean;
 
 export type OnProfileUpdated = ( type: ProfileUpdatedType ) => void;
 
 export type OnOpened = () => void;
+export type OnClosed = () => void;
 
 export type QuickEditorCoreOptions = Partial< {
 	email: string;
@@ -27,6 +30,7 @@ export type QuickEditorCoreOptions = Partial< {
 	locale: string;
 	onProfileUpdated: OnProfileUpdated;
 	onOpened: OnOpened;
+	onClosed: OnClosed;
 } >;
 
 export class GravatarQuickEditorCore {
@@ -36,14 +40,17 @@ export class GravatarQuickEditorCore {
 	_locale: string;
 	_onProfileUpdated: OnProfileUpdated;
 	_onOpened: OnOpened;
+	_onClosed: OnClosed;
+	_window: Window | null = null;
 
-	constructor( { email, scope = [], locale, onProfileUpdated, onOpened }: QuickEditorCoreOptions ) {
+	constructor( { email, scope = [], locale, onProfileUpdated, onOpened, onClosed }: QuickEditorCoreOptions ) {
 		this._name = this._getName();
 		this._email = email;
 		this._scope = scope;
 		this._locale = locale;
 		this._onProfileUpdated = onProfileUpdated;
 		this._onOpened = onOpened;
+		this._onClosed = onClosed;
 
 		if ( ! this._scope.every( ( s ) => ScopeList.includes( s ) ) ) {
 			// eslint-disable-next-line
@@ -62,7 +69,7 @@ export class GravatarQuickEditorCore {
 		if ( ! email ) {
 			// eslint-disable-next-line
 			console.error( 'Gravatar Quick Editor: Email not provided' );
-			return;
+			return false;
 		}
 
 		email = encodeURIComponent( email );
@@ -76,11 +83,38 @@ export class GravatarQuickEditorCore {
 		const host = this._locale ? `https://${ this._locale }.gravatar.com` : 'https://gravatar.com';
 		const url = `${ host }/profile?email=${ email }&scope=${ scope }&is_quick_editor=true`;
 
-		window.open( url, this._name, options );
+		this._window = window.open( url, this._name, options );
+
+		if ( this._window === null ) {
+			// eslint-disable-next-line
+			console.error( 'Gravatar Quick Editor: Could not open window' );
+			return false;
+		}
 
 		if ( this._onOpened ) {
 			this._onOpened();
 		}
+
+		if ( this._onClosed ) {
+			const timer = setInterval( () => {
+				if ( this._window.closed ) {
+					clearInterval( timer );
+					this._onClosed();
+				}
+			}, WINDOW_CHECK_INTERVAL );
+		}
+
+		return true;
+	};
+
+	close = () => {
+		if ( this._window ) {
+			this._window.close();
+		}
+	};
+
+	isOpen: () => boolean = () => {
+		return this._window !== null && ! this._window.closed;
 	};
 
 	_getName() {


### PR DESCRIPTION
This adds some functions to determine the open/close status of the quick editor. This allows it to be used in situations where you may want to know the QE status so as to change the UI outside of the quick editor.

It will be used in the Gravatar Enhanced plugin so it can disable hovercard interactions while the QE is open, but enable them when it's closed.

## Proposed Changes

- Changes `open` to return a boolean indicating whether the popup was successful
- Adds `onClosed` callback which is called when the popup is closed
- Adds `isOpen` function to return the open/close status
- Adds `close` to programmatically close the popup

## Testing Instructions

- `npm run build`
- `npm run start` to open the playground
- Open your browser console to see further messages indicating the status of the popup window
- Note that the 'close popup' button is disabled
- Click the right 'edit avatar' to open a QE window. Note that 'close popup' button is now enabled
- Close the popup window and note the 'close popup' button is disabled
- Click 'Edit avatar' again
- Move the popup out of the way and click the 'close popup' button on the main page. The QE should disappear, and the button will be disabled
- Playground should otherwise work as expected