### PR TITLE
Fix ignoreSelector filter in wrong place

### DIFF
--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -285,12 +285,12 @@ export default class Hovercards {
 					ref: this._onQueryHovercardRef( ref ) || ref,
 				};
 			} )
+			.filter( Boolean )
 			.map( ( hovercardRef: HovercardRef ) => ( {
 				...hovercardRef,
 				onEnter: ( e: MouseEvent ) => this._handleMouseEnter( e, hovercardRef ),
 				onLeave: ( e: MouseEvent ) => this._handleMouseLeave( e, hovercardRef ),
-			} ) )
-			.filter( Boolean );
+			} ) );
 
 		return this._hovercardRefs;
 	}


### PR DESCRIPTION
In #168 a fix was put in for the detach event listeners, which weren't being cleared. The part that keeps track of the event handlers was added in the wrong place, and needs to come after we `filter` the list to remove any elements that have been ignored by the `ignoreSelector`.

## Testing Instructions

- `npm run build`
- `npm run start`
- Use the playground page and confirm everything works
- Press the recycle button to change the order of the avatars on the right and re-attach hovercards. Hover over one and confirm it shows the correct hovercard
