### PR TITLE
Hovercards: Add claim gravatar to the error status

### DIFF
--- a/web/packages/hovercards/README.md
+++ b/web/packages/hovercards/README.md
@@ -313,7 +313,7 @@ document.getElementById( 'container' ).appendChild( hovercardSkeleton );
 
 ##### `(static) createHovercardError( avatarUrl: string, message: string, options?: { additionalClass?: string; avatarAlt?: string; additionalMessage?: string } ): HTMLDivElement`
 
-This method generates an error hovercard element. It accepts the `avatarUrl` parameter, which represents the URL of the avatar image, the `message` parameter, which represents the error message, and an optional options object that can include properties such as [`additionalClass`](#additionalclass-string), [`avatarAlt`](#avataralt-string) (default: `'Avatar'`) and more. It's useful when you want to display an error message when fetching the Gravatar profile fails.
+This method generates an error hovercard element. It accepts the `avatarUrl` parameter, which represents the URL of the avatar image, the `message` parameter, which represents the error message, and an optional options object that can include properties such as [`additionalClass`](#additionalclass-string), [`avatarAlt`](#avataralt-string) (default: `'Avatar'`), among others. It's useful when you want to display an error message when fetching the Gravatar profile fails.
 
 ```js
 import { Hovercards } from '@gravatar-com/hovercards';

--- a/web/packages/hovercards/README.md
+++ b/web/packages/hovercards/README.md
@@ -311,9 +311,9 @@ const hovercardSkeleton = Hovercards.createHovercardSkeleton();
 document.getElementById( 'container' ).appendChild( hovercardSkeleton );
 ```
 
-##### `(static) createHovercardError( avatarUrl: string, message: string, options?: { additionalClass?: string; avatarAlt?: string } ): HTMLDivElement`
+##### `(static) createHovercardError( avatarUrl: string, message: string, options?: { additionalClass?: string; avatarAlt?: string; additionalMessage?: string } ): HTMLDivElement`
 
-This method generates an error hovercard element. It accepts the `avatarUrl` parameter, which represents the URL of the avatar image, the `message` parameter, which represents the error message, and an optional options object that can include properties such as [`additionalClass`](#additionalclass-string) and [`avatarAlt`](#avataralt-string) (default: `'Avatar'`). It's useful when you want to display an error message when fetching the Gravatar profile fails.
+This method generates an error hovercard element. It accepts the `avatarUrl` parameter, which represents the URL of the avatar image, the `message` parameter, which represents the error message, and an optional options object that can include properties such as [`additionalClass`](#additionalclass-string), [`avatarAlt`](#avataralt-string) (default: `'Avatar'`) and more. It's useful when you want to display an error message when fetching the Gravatar profile fails.
 
 ```js
 import { Hovercards } from '@gravatar-com/hovercards';
@@ -506,9 +506,11 @@ The following phrases are used:
 - `Contact`
 - `Send money`
 - `Sorry, we are unable to load this Gravatar profile.`
-- `Profile not found.`
+- `Gravatar not found.`
 - `Too Many Requests.`
 - `Internal Server Error.`
+- `Is this you?`
+- `Claim your free profile.`
 
 The `i18n` option is an object that maps from the English text to the language of your choice (even another English phrase, if you wish to change the text).
 

--- a/web/packages/hovercards/package.json
+++ b/web/packages/hovercards/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@gravatar-com/hovercards",
-	"version": "0.10.8",
+	"version": "0.11.0",
 	"description": "Add profile hovercards to Gravatar images.",
 	"homepage": "https://github.com/Automattic/gravatar/blob/trunk/web/packages/hovercards#readme",
 	"bugs": "https://github.com/Automattic/gravatar/issues",

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -825,7 +825,7 @@ export default class Hovercards {
 								? `
 								<i class="gravatar-hovercard__error-message gravatar-hovercard__error-message--claim-gravatar">
 									${ __t( this._i18n, 'Is this you?' ) } 
-									<a href="http://gravatar.com/signup??utm_source=hovercard" target="_blank">
+									<a href="http://gravatar.com/signup?utm_source=hovercard" target="_blank">
 										${ __t( this._i18n, 'Claim your free profile.' ) }
 									</a>
 								</i>

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -825,7 +825,9 @@ export default class Hovercards {
 								? `
 								<i class="gravatar-hovercard__error-message gravatar-hovercard__error-message--claim-gravatar">
 									${ __t( this._i18n, 'Is this you?' ) } 
-									<a href="http://gravatar.com/signup" target="_blank">${ __t( this._i18n, 'Claim your free profile.' ) }</a>
+									<a href="http://gravatar.com/signup??utm_source=hovercard" target="_blank">
+										${ __t( this._i18n, 'Claim your free profile.' ) }
+									</a>
 								</i>
 								`
 								: '';

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -78,6 +78,7 @@ export type CreateHovercardSkeleton = ( options?: CreateHovercardSkeletonOptions
 export interface CreateHovercardErrorOptions {
 	avatarAlt?: string;
 	additionalClass?: string;
+	additionalMessage?: string;
 }
 
 export type CreateHovercardError = (
@@ -672,17 +673,18 @@ export default class Hovercards {
 	/**
 	 * Creates an error hovercard element.
 	 *
-	 * @param {string} avatarUrl                 - The URL of the avatar image.
-	 * @param {string} message                   - The error message to display.
-	 * @param {Object} [options]                 - Optional parameters for the error hovercard.
-	 * @param {string} [options.avatarAlt]       - The alt text for the avatar image.
-	 * @param {string} [options.additionalClass] - Additional CSS class for the error hovercard.
-	 * @return {HTMLDivElement}                  - The created error hovercard element.
+	 * @param {string} avatarUrl                   - The URL of the avatar image.
+	 * @param {string} message                     - The error message to display.
+	 * @param {Object} [options]                   - Optional parameters for the error hovercard.
+	 * @param {string} [options.avatarAlt]         - The alt text for the avatar image.
+	 * @param {string} [options.additionalClass]   - Additional CSS class for the error hovercard.
+	 * @param {string} [options.additionalMessage] - Additional message to display in the error hovercard.
+	 * @return {HTMLDivElement}                    - The created error hovercard element.
 	 */
 	static createHovercardError: CreateHovercardError = (
 		avatarUrl,
 		message,
-		{ avatarAlt = 'Avatar', additionalClass } = {}
+		{ avatarAlt = 'Avatar', additionalClass, additionalMessage = '' } = {}
 	) => {
 		const hovercard = dc.createElement( 'div' );
 		hovercard.className = `gravatar-hovercard gravatar-hovercard--error${
@@ -692,7 +694,10 @@ export default class Hovercards {
 		hovercard.innerHTML = `
 			<div class="gravatar-hovercard__inner">
 				<img class="gravatar-hovercard__avatar" src="${ avatarUrl }" width="104" height="104" alt="${ avatarAlt }" />
-				<i class="gravatar-hovercard__error-message">${ message }</i>
+				<div class="gravatar-hovercard__error-message-wrapper">
+					<i class="gravatar-hovercard__error-message">${ message }</i>
+					${ additionalMessage }
+				</div>
 			</div>
 		`;
 
@@ -805,7 +810,7 @@ export default class Hovercards {
 
 						switch ( code ) {
 							case 404:
-								message = __t( this._i18n, 'Profile not found.' );
+								message = __t( this._i18n, 'Gravatar not found.' );
 								break;
 							case 429:
 								message = __t( this._i18n, 'Too Many Requests.' );
@@ -815,10 +820,20 @@ export default class Hovercards {
 								break;
 						}
 
+						const additionalMessage =
+							code === 404
+								? `
+								<i class="gravatar-hovercard__error-message gravatar-hovercard__error-message--claim-gravatar">
+									${ __t( this._i18n, 'Is this you?' ) } 
+									<a href="http://gravatar.com/signup" target="_blank">${ __t( this._i18n, 'Claim your free profile.' ) }</a>
+								</i>
+								`
+								: '';
+
 						const hovercardInner = Hovercards.createHovercardError(
 							`https://0.gravatar.com/avatar/${ hash }${ params }`,
 							message,
-							{ additionalClass: this._additionalClass }
+							{ additionalClass: this._additionalClass, additionalMessage }
 						).firstElementChild;
 
 						hovercard.classList.add( 'gravatar-hovercard--error' );

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -222,8 +222,18 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		gap: 34px;
 	}
 
+	.gravatar-hovercard__error-message-wrapper {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	}
+
 	.gravatar-hovercard__error-message {
 		color: $color-gray;
+
+		&.gravatar-hovercard__error-message--claim-gravatar a {
+			color: inherit;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If there is no related issue, please create one first.
-->

Related to #191 

## Proposed Changes

* Add a new `additionalMessage` option to the `createHovercardError` method
* Add the claim Gravatar message with the new option

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this PR
* `cd web/packages/hovercards && npm run build:watch`
* In a new terminal, run `npm run start`
* Hover over the invalid Gravatar user, and you will see the claim Gravatar message:
  * Click the link will go to:  http://gravatar.com/signup

<img width="440" alt="截圖 2025-04-18 下午3 56 13" src="https://github.com/user-attachments/assets/6b4506ec-e236-48b0-a478-e9d42ff6e0fb" />

