### PR TITLE
Translate contact field labels

### DIFF
--- a/web/packages/hovercards/README.md
+++ b/web/packages/hovercards/README.md
@@ -511,6 +511,12 @@ The following phrases are used:
 - `Internal Server Error.`
 - `Is this you?`
 - `Claim your free profile.`
+- `Email`
+- `Home Phone`
+- `Work Phone`
+- `Cell Phone`
+- `Contact Form`
+- `Calendar`
 
 The `i18n` option is an object that maps from the English text to the language of your choice (even another English phrase, if you wish to change the text).
 

--- a/web/packages/hovercards/playground/core.ts
+++ b/web/packages/hovercards/playground/core.ts
@@ -90,6 +90,95 @@ addEventListener( 'DOMContentLoaded', () => {
 		} )
 	);
 
+	// To test translations.
+	document.getElementById( 'translated-hovercard' )?.appendChild(
+		Hovercards.createHovercard(
+			{
+				hash: '4f615f4811330c1883eb440d6621e7c2bb8e4bbb610f74e1159d2973a0aea99f',
+				avatarUrl: 'https://0.gravatar.com/avatar/a8fb08baaca16a8c0c87177d3d54499b?size=128',
+				profileUrl: 'https://joaoheringer.link',
+				displayName: 'Joao Heringer',
+				location: 'BH - Brazil',
+				description:
+					'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus velit tellus, eleifend ut accumsan ut, imperdiet in nisi. Pellentesque ac fringilla nibh, nec malesuada urna.',
+				jobTitle: 'Frontend Scribbler',
+				company: 'Automattic',
+				headerImage:
+					"url('https://2.gravatar.com/userimage/209214672/cdebd0ed415afa2e562ba5c34b1570c2?size=1024') no-repeat 50% 1% / 100%",
+				backgroundColor: 'linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)',
+				verifiedAccounts: [
+					{
+						type: 'github',
+						label: 'GitHub',
+						icon: 'https://gravatar.com/icons/github.svg',
+						url: 'https://github.com/jcheringer',
+						isHidden: false,
+					},
+					{
+						type: 'instagram',
+						label: 'Instagram',
+						icon: 'https://gravatar.com/icons/instagram.svg',
+						url: 'https://instagram.com/jc.heringer',
+						isHidden: false,
+					},
+					{
+						type: 'calendly',
+						label: 'Calendly',
+						icon: 'https://gravatar.com/icons/calendly.svg',
+						url: 'https://calendly.com/joao-heringer',
+						isHidden: false,
+					},
+					{
+						type: 'wordpress',
+						label: 'WordPress',
+						icon: 'https://gravatar.com/icons/wordpress.svg',
+						url: 'https://jcheringer.blog',
+						isHidden: true,
+					},
+				],
+				contactInfo: {
+					home_phone: '12225556666',
+					work_phone: '12225555555',
+					cell_phone: '12312312312',
+					email: 'email@email.com',
+					contact_form: 'https://example.com',
+					calendar: 'https://calendar.com',
+				},
+				payments: {
+					links: [],
+					crypto_wallets: [
+						{
+							label: 'Ethereum',
+							address: '0xAbc12312',
+						},
+					],
+				},
+			},
+			{
+				i18n: {
+					'Edit your profile →': 'Edit your profile →',
+					'View profile →': 'Ver perfil →',
+					'Send money': 'Enviar dinero',
+					Contact: 'Contacto',
+					'Sorry, we are unable to load this Gravatar profile.':
+						'No hemos podido cargar este perfil de Gravatar.',
+					'Gravatar not found': 'Gravatar no encontrado',
+					'Too Many Requests': 'Demasiadas solicitudes',
+					'Internal Server Error': 'Error interno del servidor',
+					'Is this you?': '¿Es usted?',
+					'Claim your free profile': 'Reclama tu perfil gratuito',
+					'Embed card': 'Tarjeta incrustada',
+					Email: 'Correo electrónico',
+					'Home Phone': 'Teléfono de casa',
+					'Contact Form': 'Formulario de contacto',
+					'Work Phone': 'Teléfono de trabajo',
+					'Cell Phone': 'Teléfono móvil',
+					Calendar: 'Calendario',
+				},
+			}
+		)
+	);
+
 	// To test hovercard skeleton
 	document.getElementById( 'hovercard-skeleton' )?.appendChild( Hovercards.createHovercardSkeleton() );
 

--- a/web/packages/hovercards/playground/index.html
+++ b/web/packages/hovercards/playground/index.html
@@ -80,6 +80,7 @@
 			<div id="react-app"></div>
 			<div id="inline">
 				<div id="inline-hovercard"></div>
+				<div id="translated-hovercard"></div>
 				<div id="hovercard-skeleton"></div>
 				<div id="hovercard-error"></div>
 			</div>

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -370,7 +370,7 @@ export default class Hovercards {
 				contactsDrawer = Hovercards._createDrawer(
 					'contact',
 					__t( i18n, 'Contact' ),
-					Hovercards._createContactDrawerContent( nonEmptyContacts )
+					Hovercards._createContactDrawerContent( nonEmptyContacts, { i18n } )
 				);
 			}
 
@@ -539,11 +539,16 @@ export default class Hovercards {
 	/**
 	 * Creates the contact drawer content.
 	 *
-	 * @param {Record< string, any >[]} contactsData - The user's contact data.
-	 * @return {string}                              - The contact drawer content.
+	 * @param {Record< string, any >[]} contactsData   - The user's contact data.
+	 * @param {Object}                  [options]      - Optional parameters for the contact drawer.
+	 * @param {Record<string, string>}  [options.i18n] - The i18n object.
+	 * @return {string}                               - The contact drawer content.
 	 * @private
 	 */
-	private static _createContactDrawerContent( contactsData: Record< string, any >[] ): string {
+	private static _createContactDrawerContent(
+		contactsData: Record< string, any >[],
+		{ i18n = {} }: { i18n?: Record< string, string > } = {}
+	): string {
 		const icons: Record< string, string > = {
 			email: 'icons/mail.svg',
 			home_phone: 'icons/home-phone.svg',
@@ -552,6 +557,15 @@ export default class Hovercards {
 			contact_form: 'icons/envelope.svg',
 			calendar: 'icons/calendar.svg',
 			calendly: 'icons/calendly.svg',
+		};
+
+		const labels: Record< string, string > = {
+			email: __t( i18n, 'Email' ),
+			home_phone: __t( i18n, 'Home Phone' ),
+			work_phone: __t( i18n, 'Work Phone' ),
+			cell_phone: __t( i18n, 'Cell Phone' ),
+			contact_form: __t( i18n, 'Contact Form' ),
+			calendar: __t( i18n, 'Calendar' ),
 		};
 
 		const getUrl = ( type: string, value: string ) => {
@@ -586,7 +600,7 @@ export default class Hovercards {
 						alt=""
 					>
 					<div class="gravatar-hovercard__drawer-item-info">
-						<span class="gravatar-hovercard__drawer-item-label">${ key.replace( '_', ' ' ) }</span>
+						<span class="gravatar-hovercard__drawer-item-label">${ labels[ key ] ?? key.replace( '_', ' ' ) }</span>
 						<span class="gravatar-hovercard__drawer-item-text">${ text }</span>
 					</div>
 				</li>

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -413,7 +413,7 @@ export default class Hovercards {
 				}
 				<div class="gravatar-hovercard__social-links">
 					<a class="gravatar-hovercard__social-link" href="${ trackedProfileUrl }" target="_blank" data-service-name="gravatar">
-						<img class="gravatar-hovercard__social-icon" src="https://secure.gravatar.com/icons/gravatar.svg" width="32" height="32" alt="Gravatar" />
+						<img class="gravatar-hovercard__social-icon" src="https://s.gravatar.com/icons/gravatar.svg" width="32" height="32" alt="Gravatar" />
 					</a>
 					${ renderSocialLinks }
 				</div>
@@ -596,7 +596,7 @@ export default class Hovercards {
 						class="gravatar-hovercard__drawer-item-icon"
 						width="24"
 						height="24"
-						src="https://secure.gravatar.com/${ icons[ key ] }"
+						src="https://s.gravatar.com/${ icons[ key ] }"
 						alt=""
 					>
 					<div class="gravatar-hovercard__drawer-item-info">
@@ -623,7 +623,7 @@ export default class Hovercards {
 		payments.links?.forEach( ( item ) => {
 			items.push( `
 				<li class="gravatar-hovercard__drawer-item">
-					<img class="gravatar-hovercard__drawer-item-icon" width="24" height="24" src="https://secure.gravatar.com/icons/link.svg" alt="">
+					<img class="gravatar-hovercard__drawer-item-icon" width="24" height="24" src="https://s.gravatar.com/icons/link.svg" alt="">
 					<div class="gravatar-hovercard__drawer-item-info">
 						<span class="gravatar-hovercard__drawer-item-label">${ item.label }</span>
 						<span class="gravatar-hovercard__drawer-item-text">
@@ -639,7 +639,7 @@ export default class Hovercards {
 		payments.crypto_wallets?.forEach( ( item ) => {
 			items.push( `
 				<li class="gravatar-hovercard__drawer-item">
-					<img class="gravatar-hovercard__drawer-item-icon" width="24" height="24" src="https://secure.gravatar.com/icons/link.svg" alt="">
+					<img class="gravatar-hovercard__drawer-item-icon" width="24" height="24" src="https://s.gravatar.com/icons/link.svg" alt="">
 					<div class="gravatar-hovercard__drawer-item-info">
 						<span class="gravatar-hovercard__drawer-item-label">${ item.label }</span>
 						<span class="gravatar-hovercard__drawer-item-text">${ item.address }</span>


### PR DESCRIPTION
Fixes https://github.com/Automattic/gravatar/issues/194

## Proposed Changes

* Translate contact field labels (not related to a specific service such as Calendly)
* Switch to using `s.gravatar.com` (static CDN) instead of `secure.gravatar.com` for assets.

## Testing Instructions
- `npm run build` and `npm run start`
- Check the new second inline card to test translations