### PR TITLE
Hovercards: Implement a component-scoped CSS reset

### DIFF
--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -336,7 +336,7 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		}
 	}
 
-	&--open {
+	&.gravatar-hovercard__drawer--open {
 		visibility: visible;
 
 		.gravatar-hovercard__drawer-backdrop {
@@ -348,7 +348,7 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		}
 	}
 
-	&--closing {
+	&.gravatar-hovercard__drawer--closing {
 		visibility: visible;
 
 		.gravatar-hovercard__drawer-backdrop {

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -20,7 +20,7 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 
 	/* CSS reset for the hovercard. Add additional reset styles here if needed */
 
-	/* Common: zero out unwanted defaults */
+	/* General: zero out unwanted defaults */
 	&,
 	&::before,
 	&::after {

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -17,23 +17,66 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 }
 
 .gravatar-hovercard {
-	display: inline-block;
-	z-index: 10000000;
 
-	h4,
-	p {
+	/* CSS reset for the hovercard. Add additional reset styles here if needed */
+
+	/* Common: zero out unwanted defaults */
+	&,
+	&::before,
+	&::after {
+		box-sizing: border-box;
+	}
+
+	* {
 		margin: 0;
+		padding: 0;
+		border: 0;
+		box-sizing: inherit;
+		font: inherit;
+		line-height: inherit;
+		color: inherit;
+		background: transparent;
+		vertical-align: baseline;
+		list-style: none; /* covers all lists (ul, ol, li) */
+		appearance: none; /* strips native styling from every element */
+		-webkit-appearance: none;
+		-moz-appearance: none;
 	}
 
-	p,
-	i,
-	a,
-	span {
-		font-family: $font-sf-pro;
-		font-size: 14px;
-		line-height: 1.5;
-		color: $color-black;
+	/* Components */
+	a {
+		text-decoration: none;
+		cursor: pointer;
 	}
+
+	button {
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+	}
+
+	img,
+	svg {
+		display: block; /* avoids inline whitespace */
+		max-width: 100%;
+		height: auto;
+	}
+
+	/* States */
+	a:focus-visible,
+	button:focus-visible {
+		outline: 2px solid revert;
+	}
+
+	/* End of CSS reset */
+
+	display: inline-block;
+	font-family: $font-sf-pro;
+	font-size: 14px;
+	line-height: 1.5;
+	color: $color-black;
+	z-index: 10000000;
 
 	.gravatar-hovercard__inner {
 		display: flex;
@@ -47,7 +90,6 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		border: 1px solid $color-light-gray;
 		border-radius: 4px;
 		box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
-		box-sizing: border-box;
 		overflow: hidden;
 	}
 
@@ -67,18 +109,13 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		gap: 8px;
 	}
 
-	.gravatar-hovercard__avatar-link,
-	.gravatar-hovercard__social-link {
-		display: inline-flex;
+	.gravatar-hovercard__avatar-link {
+		width: fit-content;
 	}
 
 	.gravatar-hovercard__avatar {
 		border-radius: 50%;
 		background-color: $color-super-light-gray;
-	}
-
-	.gravatar-hovercard__personal-info-link {
-		text-decoration: none;
 	}
 
 	.gravatar-hovercard__name {
@@ -89,7 +126,6 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		font-size: 32px;
 		font-weight: 700;
 		line-height: 38px;
-		color: $color-black;
 	}
 
 	.gravatar-hovercard__job,
@@ -101,7 +137,6 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 	}
 
 	.gravatar-hovercard__body {
-		min-height: 42px;
 		margin-top: 8px;
 	}
 
@@ -127,7 +162,6 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		width: 100%;
 		min-height: 42px;
 		padding: 8px;
-		background: unset;
 		border-radius: 4px;
 		border: 1px solid rgba($color-blue, 0.3);
 		font-family: $font-sf-pro;
@@ -135,7 +169,6 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		font-weight: 600;
 		line-height: 21px;
 		color: $color-blue;
-		cursor: pointer;
 
 		&:hover {
 			border: 1px solid rgba($color-blue, 0.6);
@@ -157,12 +190,9 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		/* Ensure consistent word-breaking across browsers. */
 		word-break: break-all;
 		color: $color-gray;
-
-		text-decoration: none;
 	}
 
 	.gravatar-hovercard__profile-link {
-		text-decoration: none;
 		flex-shrink: 0;
 		color: $color-gray;
 	}
@@ -232,7 +262,7 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		color: $color-gray;
 
 		&.gravatar-hovercard__error-message--claim-gravatar a {
-			color: inherit;
+			text-decoration: underline;
 		}
 	}
 }
@@ -270,7 +300,6 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		border-top-left-radius: 4px;
 		border-top-right-radius: 4px;
 		padding: 20px 0;
-		box-sizing: border-box;
 		transform: translate3d(0, 100%, 0);
 		transition: transform 0.3s ease-in-out;
 	}
@@ -288,31 +317,25 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		font-size: 18px;
 		font-weight: 700;
 		line-height: 27px;
-		margin: 0;
 	}
 
 	.gravatar-hovercard__drawer-close {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		border: none;
-		background: none;
-		padding: 0;
-		cursor: pointer;
 	}
 
 	.gravatar-hovercard__drawer-items {
 		display: flex;
 		flex-direction: column;
-		list-style: none;
-		margin: 0;
 		padding: 0 20px;
 		gap: 12px;
-		overflow: auto;
+		overflow-y: auto;
 	}
 
 	.gravatar-hovercard__drawer-item {
 		display: flex;
+		align-items: start;
 		gap: 8px;
 	}
 
@@ -329,7 +352,6 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 
 	.gravatar-hovercard__drawer-item-link {
 		color: $color-blue;
-		text-decoration: none;
 
 		&:hover {
 			text-decoration: underline;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If there is no related issue, please create one first.
-->

This PR implements a (robust) component-scoped CSS reset to prevent the hovercard's styles from being overridden by the themes of the website (e.g., WordPress sites)

- Related to #197
- Related to https://github.com/Automattic/gravatar-enhanced/issues/55

## Proposed Changes

* Implement the component-scoped CSS reset
* Remove redundant and unnecessary CSS props due to the newly added CSS reset
* Use full class names to make parsing easier for the code editor
* Improve the styles a little bit

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  Check out this PR
* Run `cd web/packages/hovercards && npm run build`
* Open a new terminal, and run `npm start`
* Check the hovercards it still works the same:

<img width="343" alt="截圖 2025-04-29 凌晨1 41 25" src="https://github.com/user-attachments/assets/1d2317e6-7b3c-4202-aba3-755b847b866f" />
<img width="347" alt="截圖 2025-04-29 凌晨1 41 31" src="https://github.com/user-attachments/assets/6780c589-c56e-4ea1-aecd-f32f08b75871" />

* Check the error state, it still works the same:

<img width="350" alt="截圖 2025-04-29 凌晨1 41 12" src="https://github.com/user-attachments/assets/8470ef1d-31c0-4076-b0ca-83587780f9a3" />

* Check the loading state, it still works the same:

<img width="351" alt="截圖 2025-04-29 凌晨1 41 56" src="https://github.com/user-attachments/assets/0ba93463-6e5c-4f86-a0fd-0e1be4a91029" />
