### PR TITLE
Hovercards: Handle default header image

### DIFF
--- a/web/packages/hovercards/README.md
+++ b/web/packages/hovercards/README.md
@@ -240,6 +240,7 @@ interface ProfileData {
     jobTitle?: string;
     company?: string;
     headerImage?: string;
+    hideDefaultHeaderImage?: boolean;
     backgroundColor?: string;
     verifiedAccounts?: Record< 'label' | 'icon' | 'url' | 'type', string >[];
     contactInfo?: ContactInfo;

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -374,8 +374,8 @@ export default class Hovercards {
 		let sendMoneyDrawer = '';
 
 		if ( headerImage || ! hideDefaultHeaderImage ) {
-			const img = ! headerImage ? `<img src="${ escUrl( avatarUrl ) }" alt=""/>` : '';
-			headerImageHtml = `<div class="gravatar-hovercard__header-image">${ img }</div>`;
+			const img = `<img class="gravatar-hovercard__header-image-img" src="${ escUrl( avatarUrl ) }" alt=""/>`;
+			headerImageHtml = `<div class="gravatar-hovercard__header-image">${ ! headerImage ? img : '' }</div>`;
 		}
 
 		if ( nonEmptyContacts.length || hasPayments ) {
@@ -805,6 +805,7 @@ export default class Hovercards {
 							jobTitle: data.job_title,
 							company: data.company,
 							headerImage: data.header_image,
+							hideDefaultHeaderImage: data.hide_default_header_image,
 							backgroundColor: data.background_color,
 							verifiedAccounts: data.verified_accounts?.map( ( account: AccountData ) => ( {
 								type: account.service_type,

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -55,6 +55,7 @@ export interface ProfileData {
 	jobTitle?: string;
 	company?: string;
 	headerImage?: string;
+	hideDefaultHeaderImage?: boolean;
 	backgroundColor?: string;
 	verifiedAccounts?: VerifiedAccount[];
 	contactInfo?: ContactInfo;
@@ -326,6 +327,7 @@ export default class Hovercards {
 			jobTitle,
 			company,
 			headerImage,
+			hideDefaultHeaderImage,
 			verifiedAccounts = [],
 			payments,
 			contactInfo,
@@ -402,7 +404,9 @@ export default class Hovercards {
 
 		hovercard.innerHTML = `
 			<div class="gravatar-hovercard__inner">
-				${ headerImage ? `<div class="gravatar-hovercard__header-image"></div>` : '' }
+				<div class="gravatar-hovercard__header-image">
+					${ ! headerImage && ! hideDefaultHeaderImage ? `<img src="${ escUrl( avatarUrl ) }" alt=""/>` : '' }
+				</div>
 				<div class="gravatar-hovercard__header">
 					<a class="gravatar-hovercard__avatar-link" href="${ trackedProfileUrl }" target="_blank">
 						<img class="gravatar-hovercard__avatar" src="${ escUrl( avatarUrl ) }" width="104" height="104" alt="${ username }" />

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -368,9 +368,15 @@ export default class Hovercards {
 			}, [] )
 			.join( '' );
 
+		let headerImageHtml = '';
 		let ctaButtons = '';
 		let contactsDrawer = '';
 		let sendMoneyDrawer = '';
+
+		if ( headerImage || ! hideDefaultHeaderImage ) {
+			const img = ! headerImage ? `<img src="${ escUrl( avatarUrl ) }" alt=""/>` : '';
+			headerImageHtml = `<div class="gravatar-hovercard__header-image">${ img }</div>`;
+		}
 
 		if ( nonEmptyContacts.length || hasPayments ) {
 			if ( nonEmptyContacts.length ) {
@@ -404,9 +410,7 @@ export default class Hovercards {
 
 		hovercard.innerHTML = `
 			<div class="gravatar-hovercard__inner">
-				<div class="gravatar-hovercard__header-image">
-					${ ! headerImage && ! hideDefaultHeaderImage ? `<img src="${ escUrl( avatarUrl ) }" alt=""/>` : '' }
-				</div>
+				${ headerImageHtml }
 				<div class="gravatar-hovercard__header">
 					<a class="gravatar-hovercard__avatar-link" href="${ trackedProfileUrl }" target="_blank">
 						<img class="gravatar-hovercard__avatar" src="${ escUrl( avatarUrl ) }" width="104" height="104" alt="${ username }" />

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -101,13 +101,13 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		width: 100%;
 		transform: translateX(-50%);
 		overflow-y: hidden;
+	}
 
-		img {
-			width: 100%;
-			object-fit: cover;
-			transform: translateY(-30%);
-			filter: blur(40px);
-		}
+	.gravatar-hovercard__header-image-img {
+		width: 100%;
+		object-fit: cover;
+		transform: translateY(-30%);
+		filter: blur(40px);
 	}
 
 	.gravatar-hovercard__header {

--- a/web/packages/hovercards/src/style.scss
+++ b/web/packages/hovercards/src/style.scss
@@ -100,6 +100,14 @@ $font-sf-pro: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Robo
 		height: 75px;
 		width: 100%;
 		transform: translateX(-50%);
+		overflow-y: hidden;
+
+		img {
+			width: 100%;
+			object-fit: cover;
+			transform: translateY(-30%);
+			filter: blur(40px);
+		}
 	}
 
 	.gravatar-hovercard__header {


### PR DESCRIPTION
## Proposed Changes

This PR updates the Hovercards to show a default header image when the user doesn't have an uploaded image.

It also introduces the field `hideDefaultHeaderImage ` to allow users to hide the default header image.
The field is opt-out by default, which means it will show a default header image (when appropriate) unless the user chooses to opt out.

<img width="364" height="526" alt="Screenshot 2025-08-13 at 16 08 37" src="https://github.com/user-attachments/assets/4fbcb7f3-8add-4326-b84d-72cd1927bbb6" />


## Testing Instructions

* Checkout this branch and run the Hovercards playground
* Hover the mouse over an avatar without a header image - it should show the default header image
* Adjust the playground data to set `hideDefaultHeaderImage` to true - the affected card should not show the default header image now
