### PR TITLE
Hovercards: handle HTTP 403 for private Gravatar profiles

### DIFF
--- a/web/packages/hovercards/README.md
+++ b/web/packages/hovercards/README.md
@@ -512,6 +512,7 @@ The following phrases are used:
 - `Send money`
 - `Sorry, we are unable to load this Gravatar profile.`
 - `Gravatar not found.`
+- `This profile is private.`
 - `Too Many Requests.`
 - `Internal Server Error.`
 - `Is this you?`

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -840,20 +840,20 @@ export default class Hovercards {
 					.catch( ( code ) => {
 						let message = __t( this._i18n, 'Sorry, we are unable to load this Gravatar profile.' );
 
-					switch ( code ) {
-						case 403:
-							message = __t( this._i18n, 'This profile is private.' );
-							break;
-						case 404:
-							message = __t( this._i18n, 'Gravatar not found.' );
-							break;
-						case 429:
-							message = __t( this._i18n, 'Too Many Requests.' );
-							break;
-						case 500:
-							message = __t( this._i18n, 'Internal Server Error.' );
-							break;
-					}
+						switch ( code ) {
+							case 403:
+								message = __t( this._i18n, 'This profile is private.' );
+								break;
+							case 404:
+								message = __t( this._i18n, 'Gravatar not found.' );
+								break;
+							case 429:
+								message = __t( this._i18n, 'Too Many Requests.' );
+								break;
+							case 500:
+								message = __t( this._i18n, 'Internal Server Error.' );
+								break;
+						}
 
 						const additionalMessage =
 							code === 404

--- a/web/packages/hovercards/src/core.ts
+++ b/web/packages/hovercards/src/core.ts
@@ -840,17 +840,20 @@ export default class Hovercards {
 					.catch( ( code ) => {
 						let message = __t( this._i18n, 'Sorry, we are unable to load this Gravatar profile.' );
 
-						switch ( code ) {
-							case 404:
-								message = __t( this._i18n, 'Gravatar not found.' );
-								break;
-							case 429:
-								message = __t( this._i18n, 'Too Many Requests.' );
-								break;
-							case 500:
-								message = __t( this._i18n, 'Internal Server Error.' );
-								break;
-						}
+					switch ( code ) {
+						case 403:
+							message = __t( this._i18n, 'This profile is private.' );
+							break;
+						case 404:
+							message = __t( this._i18n, 'Gravatar not found.' );
+							break;
+						case 429:
+							message = __t( this._i18n, 'Too Many Requests.' );
+							break;
+						case 500:
+							message = __t( this._i18n, 'Internal Server Error.' );
+							break;
+					}
 
 						const additionalMessage =
 							code === 404


### PR DESCRIPTION
## Problem

When a Gravatar user sets their profile to **private**, the Gravatar API returns HTTP 403 (Forbidden). However, the hovercards client currently has no handler for 403 — it falls through to the generic error message. The result is the misleading hovercard:

> **Gravatar not found.**
> *Is this you? Claim your free profile.*

This is confusing because the user _does_ have a Gravatar — they've simply chosen to keep their profile private.

## Fix

Add a `case 403` branch to the error `switch` in `_showHovercard` that shows **"This profile is private."** instead.

The `additionalMessage` "Is this you? Claim your free profile." CTA is already gated on `code === 404`, so it is correctly suppressed for private profiles with no additional changes needed.

Also adds the new `'This profile is private.'` key to the i18n documentation in the README.

## Changes

- `src/core.ts` — add `case 403` to the fetch error handler
- `README.md` — document the new `'This profile is private.'` i18n key

## Related

- **Jetpack monorepo** — [Automattic/jetpack#47594](https://github.com/Automattic/jetpack/pull/47594): Adds the `'This profile is private.'` i18n translation key to `packages/forms` and `packages/jetpack-mu-wpcom` (verbum-comments), and fixes a pre-existing wrong key in verbum-comments.

## Note

This client-side fix requires a companion change in the Gravatar API backend to return **HTTP 403** (not 404) for private profiles. Without that API change, private profiles continue to hit `case 404`. This PR prepares the client to handle the correct status code once the API is updated.