### PR TITLE
Hovercards Release: Use Trusted Publishing instead of NPM Access Token

### DIFF
--- a/.github/workflows/hovercards-release.yml
+++ b/.github/workflows/hovercards-release.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade NPM
         run: npm install -g npm@latest

--- a/.github/workflows/hovercards-release.yml
+++ b/.github/workflows/hovercards-release.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # Required for NPM Trusted Publishing (OIDC)
 
     steps: 
       - name: Checkout repo
@@ -31,22 +32,19 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      - name: Upgrade NPM
+        run: npm install -g npm@latest
+
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Initialize Git user
         run: |
           git config user.name "gravatar-automattic"
           git config user.email "gravatar@automattic.com"
 
-      - name: Initialize the NPM config
-        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Release
         working-directory: web/packages/hovercards
         run: npx release-it ${{ github.event.inputs.increment }} --ci
         env: 
           GITHUB_TOKEN: ${{ secrets.GRAVATAR_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/web/packages/hovercards/.release-it.json
+++ b/web/packages/hovercards/.release-it.json
@@ -13,7 +13,8 @@
 		"assets": [ "release/hovercards.zip" ]
 	},
 	"npm": {
-		"publish": true
+		"publish": true,
+		"skipChecks": true
 	},
 	"hooks": {
 		"before:init": [


### PR DESCRIPTION
## Proposed Changes

In the Hovercards Release action, remove the reliance on an NPM Access Token and instead switch to Trusted Publishing:
* https://github.com/release-it/release-it/blob/main/docs/npm.md#trusted-publishing-oidc
* https://docs.npmjs.com/trusted-publishers

## Testing Instructions

YOLO?