### PR TITLE
Hovercards: Fix Repository URL

### DIFF
--- a/web/packages/hovercards/package.json
+++ b/web/packages/hovercards/package.json
@@ -4,7 +4,11 @@
 	"description": "Add profile hovercards to Gravatar images.",
 	"homepage": "https://github.com/Automattic/gravatar/blob/trunk/web/packages/hovercards#readme",
 	"bugs": "https://github.com/Automattic/gravatar/issues",
-	"repository": "https://github.com/Automattic/gravatar/blob/trunk/web/packages/hovercards",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/gravatar.git",
+		"directory": "web/packages/hovercards"
+	},
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",
 	"keywords": [


### PR DESCRIPTION
## Proposed Changes

NPM Provenance demands that the repository URL be the base URL of repo.

Explicitly specify repository.directory to make it clear where the source lives.

https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository