### PR TITLE
Quick Editor Release: Use Trusted Publishing instead of NPM Access Token

### DIFF
--- a/.github/workflows/quick-editor-release.yml
+++ b/.github/workflows/quick-editor-release.yml
@@ -17,8 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # Required for NPM Trusted Publishing (OIDC)
 
-    steps: 
+    steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
@@ -30,23 +31,21 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade NPM
+        run: npm install -g npm@latest
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Initialize Git user
         run: |
           git config user.name "gravatar-automattic"
           git config user.email "gravatar@automattic.com"
 
-      - name: Initialize the NPM config
-        run: npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Release
         working-directory: web/packages/quick-editor
         run: npx release-it ${{ github.event.inputs.increment }} --ci
-        env: 
+        env:
           GITHUB_TOKEN: ${{ secrets.GRAVATAR_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/web/packages/quick-editor/.release-it.json
+++ b/web/packages/quick-editor/.release-it.json
@@ -13,7 +13,8 @@
 		"assets": [ "release/quick-editor.zip" ]
 	},
 	"npm": {
-		"publish": true
+		"publish": true,
+		"skipChecks": true
 	},
 	"hooks": {
 		"before:init": [

--- a/web/packages/quick-editor/package.json
+++ b/web/packages/quick-editor/package.json
@@ -64,6 +64,11 @@
 	"engines": {
 		"node": ">=20"
 	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/gravatar.git",
+		"directory": "web/packages/quick-editor"
+	},
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
## Proposed Changes

1. Add Repository URL NPM Provenance demands that the repository URL be the base URL of repo.

   Explicitly specify repository.directory to make it clear where the source lives.

   https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository
2. Removes NPM Access Token and switches release-it to use Trusted Publishing
   * https://docs.npmjs.com/trusted-publishers
   * https://github.com/release-it/release-it/blob/main/docs/npm.md#trusted-publishing-oidc

See
* https://github.com/Automattic/gravatar/pull/254
* https://github.com/Automattic/gravatar/pull/255